### PR TITLE
issue #184: Adds some duration operators to SPARQL extended mode

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
@@ -7,20 +7,23 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.Compare;
+import org.eclipse.rdf4j.query.algebra.MathExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.XMLDatatypeMathUtil;
 
 /**
  * SPARQL 1.1 extended query evaluation strategy. This strategy adds the use of virtual properties, as well as
- * extended comparison operators to the minimally-conforming {@link StrictEvaluationStrategy}.
+ * extended comparison and mathematical operators to the minimally-conforming {@link StrictEvaluationStrategy}.
  * 
  * @author Jeen Broekstra
  */
@@ -42,6 +45,20 @@ public class ExtendedEvaluationStrategy extends TupleFunctionEvaluationStrategy 
 		// return result of non-strict comparison.
 		return BooleanLiteral.valueOf(
 				QueryEvaluationUtil.compare(leftVal, rightVal, node.getOperator(), false));
+	}
+
+	@Override
+	public Value evaluate(MathExpr node, BindingSet bindings)
+			throws ValueExprEvaluationException, QueryEvaluationException
+	{
+		Value leftVal = evaluate(node.getLeftArg(), bindings);
+		Value rightVal = evaluate(node.getRightArg(), bindings);
+
+		if (leftVal instanceof Literal && rightVal instanceof Literal) {
+			return XMLDatatypeMathUtil.compute((Literal)leftVal, (Literal)rightVal, node.getOperator());
+		}
+
+		throw new ValueExprEvaluationException("Both arguments must be literals");
 	}
 
 }

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/XMLDatatypeMathUtil.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/util/XMLDatatypeMathUtil.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.util;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.query.algebra.MathExpr.MathOp;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+
+import javax.xml.datatype.*;
+
+/**
+ * A utility class for evaluation of extended "mathematical" expressions on RDF literals.
+ * They do not work only on numeric literals but also on durations
+ *
+ * @author Thomas Pellissier Tanon
+ */
+public class XMLDatatypeMathUtil {
+
+	/**
+	 * Computes the result of applying the supplied math operator on the supplied left and right operand.
+	 *
+	 * @param leftLit
+	 *		a datatype literal
+	 * @param rightLit
+	 *		a datatype literal
+	 * @param op
+	 *		a mathematical operator, as definied by MathExpr.MathOp.
+	 * @return a datatype literal
+	 */
+	public static Literal compute(Literal leftLit, Literal rightLit, MathOp op)
+			throws ValueExprEvaluationException
+	{
+		IRI leftDatatype = leftLit.getDatatype();
+		IRI rightDatatype = rightLit.getDatatype();
+
+		if(XMLDatatypeUtil.isNumericDatatype(leftDatatype) && XMLDatatypeUtil.isNumericDatatype(rightDatatype)) {
+			return MathUtil.compute(leftLit, rightLit, op);
+		}
+		else if(XMLDatatypeUtil.isDurationDatatype(leftDatatype) && XMLDatatypeUtil.isDurationDatatype(rightDatatype)) {
+			return operationsBetweenDurations(leftLit, rightLit, op);
+		}
+		else if(XMLDatatypeUtil.isDecimalDatatype(leftDatatype) && XMLDatatypeUtil.isDurationDatatype(rightDatatype)) {
+			return operationsBetweenDurationAndDecimal(rightLit, leftLit, op);
+		}
+		else if(XMLDatatypeUtil.isDurationDatatype(leftDatatype) && XMLDatatypeUtil.isDecimalDatatype(rightDatatype)) {
+			return operationsBetweenDurationAndDecimal(leftLit, rightLit, op);
+		}
+		else if(XMLDatatypeUtil.isCalendarDatatype(leftDatatype) && XMLDatatypeUtil.isDurationDatatype(rightDatatype)) {
+			return operationsBetweenCalendarAndDuration(leftLit, rightLit, op);
+		}
+		else if(XMLDatatypeUtil.isDurationDatatype(leftDatatype) && XMLDatatypeUtil.isCalendarDatatype(rightDatatype)) {
+			return operationsBetweenDurationAndCalendar(leftLit, rightLit, op);
+		}
+		else {
+			throw new ValueExprEvaluationException("Mathematical operators are not supported on these operands");
+		}
+	}
+
+	private static Literal operationsBetweenDurations(Literal leftLit, Literal rightLit, MathOp op) {
+		Duration left = XMLDatatypeUtil.parseDuration(leftLit.getLabel());
+		Duration right = XMLDatatypeUtil.parseDuration(rightLit.getLabel());
+		try {
+			switch (op) {
+				case PLUS:
+					//op:add-yearMonthDurations and op:add-dayTimeDurations
+					return buildLiteral(left.add(right));
+				case MINUS:
+					//op:subtract-yearMonthDurations and op:subtract-dayTimeDurations
+					return buildLiteral(left.subtract(right));
+				case MULTIPLY:
+					throw new ValueExprEvaluationException("Multiplication is not defined on xsd:duration.");
+				case DIVIDE:
+					throw new ValueExprEvaluationException("Division is not defined on xsd:duration.");
+				default:
+					throw new IllegalArgumentException("Unknown operator: " + op);
+			}
+		}
+		catch (IllegalStateException e) {
+			throw new ValueExprEvaluationException(e);
+		}
+	}
+
+	private static Literal operationsBetweenDurationAndDecimal(Literal durationLit, Literal decimalLit, MathOp op) {
+		Duration duration = XMLDatatypeUtil.parseDuration(durationLit.getLabel());
+
+		try {
+			if(op == MathOp.MULTIPLY) {
+				//op:multiply-dayTimeDuration and op:multiply-yearMonthDuration
+				return buildLiteral(duration.multiply(decimalLit.decimalValue()));
+			}
+			else {
+				throw new ValueExprEvaluationException("Only multiplication is defined between xsd:decimal and xsd:duration.");
+			}
+		}
+		catch (IllegalStateException e) {
+			throw new ValueExprEvaluationException(e);
+		}
+	}
+
+	private static Literal operationsBetweenCalendarAndDuration(Literal calendarLit, Literal durationLit, MathOp op) {
+		XMLGregorianCalendar calendar = (XMLGregorianCalendar) calendarLit.calendarValue().clone();
+		Duration duration = XMLDatatypeUtil.parseDuration(durationLit.getLabel());
+
+		try {
+			switch (op) {
+				case PLUS:
+					//op:add-yearMonthDuration-to-dateTime and op:add-dayTimeDuration-to-dateTime and
+					//op:add-yearMonthDuration-to-date and op:add-dayTimeDuration-to-date and
+					//op:add-dayTimeDuration-to-time
+					calendar.add(duration);
+					return SimpleValueFactory.getInstance().createLiteral(calendar);
+				case MINUS:
+					//op:subtract-yearMonthDuration-from-dateTime and op:subtract-dayTimeDuration-from-dateTime and
+					//op:subtract-yearMonthDuration-from-date and op:subtract-dayTimeDuration-from-date and
+					//op:subtract-dayTimeDuration-from-time
+					calendar.add(duration.negate());
+					return SimpleValueFactory.getInstance().createLiteral(calendar);
+				case MULTIPLY:
+					throw new ValueExprEvaluationException("Multiplication is not defined between xsd:duration and calendar values.");
+				case DIVIDE:
+					throw new ValueExprEvaluationException("Division is not defined between xsd:duration and calendar values.");
+				default:
+					throw new IllegalArgumentException("Unknown operator: " + op);
+			}
+		}
+		catch (IllegalStateException e) {
+			throw new ValueExprEvaluationException(e);
+		}
+	}
+
+	private static Literal operationsBetweenDurationAndCalendar(Literal durationLit, Literal calendarLit, MathOp op) {
+		Duration duration = XMLDatatypeUtil.parseDuration(durationLit.getLabel());
+		XMLGregorianCalendar calendar = (XMLGregorianCalendar) calendarLit.calendarValue().clone();
+
+		try {
+			if(op == MathOp.PLUS) {
+				//op:add-yearMonthDuration-to-dateTime and op:add-dayTimeDuration-to-dateTime and
+				//op:add-yearMonthDuration-to-date and op:add-dayTimeDuration-to-date and
+				//op:add-dayTimeDuration-to-time
+				calendar.add(duration);
+				return SimpleValueFactory.getInstance().createLiteral(calendar);
+			}
+			else {
+				throw new ValueExprEvaluationException("Only addition is defined between xsd:duration and calendar datatypes.");
+			}
+		}
+		catch (IllegalStateException e) {
+			throw new ValueExprEvaluationException(e);
+		}
+	}
+
+	private static Literal buildLiteral(Duration duration) {
+		return SimpleValueFactory.getInstance().createLiteral(
+				duration.toString(),
+				getDatatypeForDuration(duration)
+		);
+	}
+
+	private static IRI getDatatypeForDuration(Duration duration) {
+		//Could not be implemented with Duration.getXMLSchemaType that is too strict ("P1Y" is considered invalid)
+
+		boolean yearSet = duration.isSet(DatatypeConstants.YEARS);
+		boolean monthSet = duration.isSet(DatatypeConstants.MONTHS);
+		boolean daySet = duration.isSet(DatatypeConstants.DAYS);
+		boolean hourSet = duration.isSet(DatatypeConstants.HOURS);
+		boolean minuteSet = duration.isSet(DatatypeConstants.MINUTES);
+		boolean secondSet = duration.isSet(DatatypeConstants.SECONDS);
+
+		if(!yearSet && !monthSet) {
+			return XMLSchema.DAYTIMEDURATION;
+		}
+		if(!daySet && !hourSet && !minuteSet && !secondSet) {
+			return XMLSchema.YEARMONTHDURATION;
+		}
+		return XMLSchema.DURATION;
+	}
+}

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/XMLDatatypeMathUtilTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/XMLDatatypeMathUtilTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.util;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.eclipse.rdf4j.query.algebra.MathExpr.MathOp;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Thomas Pellissier Tanon
+ */
+public class XMLDatatypeMathUtilTest {
+
+	private ValueFactory vf = SimpleValueFactory.getInstance();
+
+	@Test
+	public void testCompute() throws Exception
+	{
+		Literal float1 = vf.createLiteral("12", XMLSchema.INTEGER);
+		Literal float2 = vf.createLiteral("2", XMLSchema.INTEGER);
+		Literal duration1 = vf.createLiteral("P1Y1M", XMLSchema.YEARMONTHDURATION);
+		Literal duration2 = vf.createLiteral("P1Y", XMLSchema.YEARMONTHDURATION);
+		Literal yearMonth1 = vf.createLiteral("2012-10", XMLSchema.GYEARMONTH);
+
+		assertComputeEquals(vf.createLiteral("14", XMLSchema.INTEGER), float1, float2, MathOp.PLUS);
+		assertComputeEquals(vf.createLiteral("10", XMLSchema.INTEGER), float1, float2, MathOp.MINUS);
+		assertComputeEquals(vf.createLiteral("24", XMLSchema.INTEGER), float1, float2, MathOp.MULTIPLY);
+		assertComputeEquals(vf.createLiteral("6", XMLSchema.DECIMAL), float1, float2, MathOp.DIVIDE);
+
+		assertComputeEquals(vf.createLiteral("P2Y1M", XMLSchema.YEARMONTHDURATION), duration1, duration2, MathOp.PLUS);
+		assertComputeEquals(vf.createLiteral("P0Y1M", XMLSchema.YEARMONTHDURATION), duration1, duration2, MathOp.MINUS);
+
+		assertComputeEquals(vf.createLiteral("P12Y", XMLSchema.YEARMONTHDURATION), float1, duration2, MathOp.MULTIPLY);
+		assertComputeEquals(vf.createLiteral("P12Y", XMLSchema.YEARMONTHDURATION), duration2, float1, MathOp.MULTIPLY);
+
+		assertComputeEquals(vf.createLiteral("2013-11", XMLSchema.GYEARMONTH), yearMonth1, duration1, MathOp.PLUS);
+		assertComputeEquals(vf.createLiteral("2011-09", XMLSchema.GYEARMONTH), yearMonth1, duration1, MathOp.MINUS);
+		assertComputeEquals(vf.createLiteral("2013-11", XMLSchema.GYEARMONTH), duration1, yearMonth1, MathOp.PLUS);
+	}
+
+	private void assertComputeEquals(Literal result, Literal lit1, Literal lit2, MathOp op)
+		throws Exception
+	{
+		assertEquals(result, XMLDatatypeMathUtil.compute(lit1, lit2, op));
+	}
+}


### PR DESCRIPTION
I have only implemented operations that are provided by javax.xml.datatype and that should be conform to the XPath and XQuery operators specification.

This PR addresses GitHub issue: #184 .
