### PR TITLE
Fix eclipse/rdf4j#940: Synchronize RangeIterator#close

### DIFF
--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTree.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/btree/BTree.java
@@ -2157,7 +2157,7 @@ public class BTree implements Closeable {
 		}
 
 		@Override
-		public void close()
+		public synchronized void close()
 			throws IOException
 		{
 			btreeLock.readLock().lock();


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: eclipse/rdf4j#940 .

* Add synchronized flag to close() method in the event that it is called from an interrupt handler
