### PR TITLE
Issue #919: Update maven-compiler-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
 		<profile>
 			<id>doclint-java8-disable</id>
 			<activation>
-				<jdk>[1.8,)</jdk>
+				<jdk>[1.8,9,)</jdk>
 			</activation>
 			<properties>
 				<javadoc.opts>-Xdoclint:none</javadoc.opts>
@@ -644,7 +644,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.6.0</version>
+					<version>3.7.0</version>
 					<configuration>
 						<fork>true</fork>
 						<source>1.8</source>
@@ -783,7 +783,7 @@
 				<plugin>
 					<groupId>com.github.siom79.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.9.3</version>
+					<version>0.11.0</version>
 					<configuration>
 						<oldVersion>
 							<dependency>
@@ -839,7 +839,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<version>1.14</version>
+				<version>1.16</version>
 				<executions>
 					<execution>
 						<phase>test</phase>


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j#919 .

* Update maven-compiler-plugin to a version that supports java 9
* Update japicmp-maven-plugin to a version that support java 9
