### PR TITLE
Issue eclipse/rdf4j#919: Fix jdk9 compile error

### DIFF
--- a/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/AbstractStringReplacer.java
+++ b/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/AbstractStringReplacer.java
@@ -50,7 +50,7 @@ abstract class AbstractStringReplacer implements Function {
 			String g = matcher.group();
 			matcher.appendReplacement(buf, transform(g));
 		}
-		matcher.appendTail(null);
+		matcher.appendTail(buf);
 		return valueFactory.createLiteral(buf.toString());
 	}
 


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j#919 .

* Matcher has two methods matching appendTail(null)
* Change the call to pass in buf as intended
