### PR TITLE
Issue #919: Add jdk9 profiles to add-modules java.xml.bind for tests

### DIFF
--- a/compliance/solr/pom.xml
+++ b/compliance/solr/pom.xml
@@ -71,4 +71,30 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<id>jdk9</id>
+			<activation>
+				<jdk>[1.9,9,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.apache.solr</groupId>
+					<artifactId>solr-core</artifactId>
+					<version>${solr.version}</version>
+					<optional>true</optional>
+					<exclusions>
+						<exclusion>
+							<groupId>log4j</groupId>
+							<artifactId>log4j</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>jdk.tools</groupId>
+							<artifactId>jdk.tools</artifactId>
+						</exclusion>
+					</exclusions>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 </project>

--- a/lucene-spin/pom.xml
+++ b/lucene-spin/pom.xml
@@ -55,4 +55,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+	<profiles>
+		<profile>
+			<id>jdk9</id>
+			<activation>
+				<jdk>[1.9,9,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<argLine>--add-modules=java.xml.bind</argLine>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/sail-spin/pom.xml
+++ b/sail-spin/pom.xml
@@ -54,4 +54,23 @@ The SPIN SAIL adds constraint checking and inferencing using SPIN to a base SAIL
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<id>jdk9</id>
+			<activation>
+				<jdk>[1.9,9,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<argLine>--add-modules=java.xml.bind</argLine>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -42,4 +42,41 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
+	<profiles>
+		<profile>
+			<id>jdk9</id>
+			<activation>
+				<jdk>[1.9,9,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.apache.solr</groupId>
+					<artifactId>solr-core</artifactId>
+					<version>${solr.version}</version>
+					<optional>true</optional>
+					<exclusions>
+						<exclusion>
+							<groupId>log4j</groupId>
+							<artifactId>log4j</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>jdk.tools</groupId>
+							<artifactId>jdk.tools</artifactId>
+						</exclusion>
+					</exclusions>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<argLine>--add-modules=java.xml.bind</argLine>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>


This PR addresses GitHub issue: eclipse/rdf4j#919 .

* Adds jdk9 profiles to add JVM argument --add-modules=java.xml.bind
* excludes jdk.tools if jdk9
