### PR TITLE
Issue eclipse/rdf4j#438: Disable skolemization when parsing SPARQL DATA blocks

### DIFF
--- a/repository-sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SPARQLUpdateDataBlockParser.java
+++ b/repository-sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SPARQLUpdateDataBlockParser.java
@@ -92,7 +92,7 @@ public class SPARQLUpdateDataBlockParser extends TriGParser {
 	}
 
 	@Override
-	protected BNode parseNodeID()
+	protected Resource parseNodeID()
 		throws IOException, RDFParseException
 	{
 		if (isAllowBlankNodes()) {

--- a/repository-sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
+++ b/repository-sail/src/main/java/org/eclipse/rdf4j/repository/sail/helpers/SailUpdateExecutor.java
@@ -457,6 +457,7 @@ public class SailUpdateExecutor {
 		parser.setLineNumberOffset(insertDataExpr.getLineNumberOffset());
 		parser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_DATATYPE_VALUES);
 		parser.getParserConfig().addNonFatalError(BasicParserSettings.FAIL_ON_UNKNOWN_DATATYPES);
+		parser.getParserConfig().set(BasicParserSettings.SKOLEMIZE_ORIGIN, null);
 		try {
 			// TODO process update context somehow? dataset, base URI, etc.
 			parser.parse(new StringReader(insertDataExpr.getDataBlock()), "");


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j#438 .

* Fix compile error
* Override SKOLEMIZE_ORIGIN setting to ensure it is disabled
