### PR TITLE
Issue eclipse/rdf4j#960: Move rdf4j-runtime classes to federation module

### DIFF
--- a/compliance/model/pom.xml
+++ b/compliance/model/pom.xml
@@ -1,0 +1,74 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j-compliance</artifactId>
+		<version>2.3-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>rdf4j-model-compliance</artifactId>
+
+	<name>RDF4J Model compliance test</name>
+	<description>Tests for RDF4J Model</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-runtime</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-model-testsuite</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- needed for SailModelTest -->
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sail-memory</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<skipTests>true</skipTests>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>**/TestServer.java</exclude>
+					</excludes>
+				</configuration>
+				<executions>
+					<execution>
+						<id>integration-tests</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>integration-test</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>verify</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/compliance/model/src/test/java/org/eclipse/rdf4j/model/SailModelNamespacesTest.java
+++ b/compliance/model/src/test/java/org/eclipse/rdf4j/model/SailModelNamespacesTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.model;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ModelNamespacesTest;
+import org.eclipse.rdf4j.model.util.ModelException;
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.model.SailModel;
+
+/**
+ * @author Mark
+ */
+public class SailModelNamespacesTest extends ModelNamespacesTest {
+
+	private Sail sail;
+
+	private SailConnection conn;
+
+	@Override
+	protected Model getModelImplementation() {
+		sail = new MemoryStore();
+		try {
+			sail.initialize();
+			conn = sail.getConnection();
+			conn.begin();
+			return new SailModel(conn, false);
+		}
+		catch (SailException e) {
+			throw new ModelException(e);
+		}
+	}
+
+	@Override
+	public void tearDown()
+		throws Exception
+	{
+		if (conn != null) {
+			conn.commit();
+			conn.close();
+			conn = null;
+		}
+		if (sail != null) {
+			sail.shutDown();
+			sail = null;
+		}
+		super.tearDown();
+	}
+}

--- a/compliance/model/src/test/java/org/eclipse/rdf4j/model/SailModelTest.java
+++ b/compliance/model/src/test/java/org/eclipse/rdf4j/model/SailModelTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.model;
+
+import junit.framework.Test;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ModelTest;
+import org.eclipse.rdf4j.model.util.ModelException;
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.model.SailModel;
+
+/**
+ * @author Mark
+ */
+public class SailModelTest extends ModelTest {
+
+	private Sail sail;
+
+	private SailConnection conn;
+
+	public static Test suite()
+		throws Exception
+	{
+		return ModelTest.suite(SailModelTest.class);
+	}
+
+	public SailModelTest(String name) {
+		super(name);
+	}
+
+	@Override
+	public Model makeEmptyModel() {
+		sail = new MemoryStore();
+		try {
+			sail.initialize();
+			conn = sail.getConnection();
+			conn.begin();
+			return new SailModel(conn, false);
+		}
+		catch (SailException e) {
+			throw new ModelException(e);
+		}
+	}
+
+	@Override
+	protected void tearDown()
+		throws Exception
+	{
+		if (conn != null) {
+			conn.commit();
+			conn.close();
+			conn = null;
+		}
+		if (sail != null) {
+			sail.shutDown();
+			sail = null;
+		}
+		super.tearDown();
+	}
+}

--- a/compliance/model/src/test/resources/logback-test.xml
+++ b/compliance/model/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<Pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %msg%n</Pattern>
+		</encoder>
+	</appender>
+	
+	<root>
+		<level value="warn" />
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>
+

--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -12,6 +12,7 @@
 	<packaging>pom</packaging>
 
 	<modules>
+		<module>model</module>
 		<module>solr</module>
 		<module>store</module>
 		<module>serql</module>

--- a/federation/pom.xml
+++ b/federation/pom.xml
@@ -38,6 +38,11 @@ The Federation SAIL allows multiple datasets to be virtually combined into a sin
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-repository-manager</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-repository-sail</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -63,6 +68,12 @@ The Federation SAIL allows multiple datasets to be virtually combined into a sin
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/federation/src/main/java/org/eclipse/rdf4j/runtime/RepositoryManagerFederator.java
+++ b/federation/src/main/java/org/eclipse/rdf4j/runtime/RepositoryManagerFederator.java
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.runtime;
+
+import java.net.MalformedURLException;
+import java.util.Collection;
+
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigSchema;
+import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryConfig;
+import org.eclipse.rdf4j.repository.http.config.HTTPRepositoryFactory;
+import org.eclipse.rdf4j.repository.http.config.HTTPRepositorySchema;
+import org.eclipse.rdf4j.repository.manager.RepositoryManager;
+import org.eclipse.rdf4j.repository.sail.config.ProxyRepositoryFactory;
+import org.eclipse.rdf4j.repository.sail.config.ProxyRepositorySchema;
+import org.eclipse.rdf4j.repository.sail.config.SailRepositoryFactory;
+import org.eclipse.rdf4j.repository.sail.config.SailRepositorySchema;
+import org.eclipse.rdf4j.repository.sparql.config.SPARQLRepositoryConfig;
+import org.eclipse.rdf4j.repository.sparql.config.SPARQLRepositoryFactory;
+import org.eclipse.rdf4j.sail.config.SailConfigSchema;
+import org.eclipse.rdf4j.sail.federation.config.FederationConfig;
+import org.eclipse.rdf4j.sail.federation.config.FederationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for handling the details of federating "user repositories" managed by a
+ * {@link org.eclipse.rdf4j.repository.manager.RepositoryManager}.
+ * 
+ * @author Dale Visser
+ */
+public class RepositoryManagerFederator {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryManagerFederator.class);
+
+	private final RepositoryManager manager;
+
+	private final ValueFactory valueFactory;
+
+	/**
+	 * Create an instance capable of federating "user repositories" within the given
+	 * {@link org.eclipse.rdf4j.repository.manager.RepositoryManager}.
+	 * 
+	 * @param manager
+	 *        must manage the repositories to be added to new federations, and becomes the manager of any
+	 *        created federations
+	 */
+	public RepositoryManagerFederator(RepositoryManager manager) {
+		this.manager = manager;
+		this.valueFactory = SimpleValueFactory.getInstance();
+	}
+
+	/**
+	 * Adds a new repository to the {@link org.eclipse.rdf4j.repository.manager.RepositoryManager}, which is a
+	 * federation of the given repository id's, which must also refer to repositories already managed by the
+	 * {@link org.eclipse.rdf4j.repository.manager.RepositoryManager}.
+	 * 
+	 * @param fedID
+	 *        the desired identifier for the new federation repository
+	 * @param description
+	 *        the desired description for the new federation repository
+	 * @param members
+	 *        the identifiers of the repositories to federate, which must already exist and be managed by the
+	 *        {@link org.eclipse.rdf4j.repository.manager.RepositoryManager}
+	 * @param readonly
+	 *        whether the federation is read-only
+	 * @param distinct
+	 *        whether the federation enforces distinct results from its members
+	 * @throws MalformedURLException
+	 *         if the {@link org.eclipse.rdf4j.repository.manager.RepositoryManager} has a malformed location
+	 * @throws RDF4JException
+	 *         if a problem otherwise occurs while creating the federation
+	 */
+	public void addFed(String fedID, String description, Collection<String> members, boolean readonly,
+			boolean distinct)
+		throws MalformedURLException, RDF4JException
+	{
+		if (members.contains(fedID)) {
+			throw new RepositoryConfigException(
+					"A federation member may not have the same ID as the federation.");
+		}
+		Model graph = new LinkedHashModel();
+		BNode fedRepoNode = valueFactory.createBNode();
+		LOGGER.debug("Federation repository root node: {}", fedRepoNode);
+		addToGraph(graph, fedRepoNode, RDF.TYPE, RepositoryConfigSchema.REPOSITORY);
+		addToGraph(graph, fedRepoNode, RepositoryConfigSchema.REPOSITORYID,
+				valueFactory.createLiteral(fedID));
+		addToGraph(graph, fedRepoNode, RDFS.LABEL, valueFactory.createLiteral(description));
+		addImplementation(members, graph, fedRepoNode, readonly, distinct);
+		RepositoryConfig fedConfig = RepositoryConfig.create(graph, fedRepoNode);
+		fedConfig.validate();
+		manager.addRepositoryConfig(fedConfig);
+	}
+
+	private void addImplementation(Collection<String> members, Model graph, BNode fedRepoNode,
+			boolean readonly, boolean distinct)
+		throws RDF4JException, MalformedURLException
+	{
+		BNode implRoot = valueFactory.createBNode();
+		addToGraph(graph, fedRepoNode, RepositoryConfigSchema.REPOSITORYIMPL, implRoot);
+		addToGraph(graph, implRoot, RepositoryConfigSchema.REPOSITORYTYPE,
+				valueFactory.createLiteral(SailRepositoryFactory.REPOSITORY_TYPE));
+		addSail(members, graph, implRoot, readonly, distinct);
+	}
+
+	private void addSail(Collection<String> members, Model graph, BNode implRoot, boolean readonly,
+			boolean distinct)
+		throws RDF4JException, MalformedURLException
+	{
+		BNode sailRoot = valueFactory.createBNode();
+		addToGraph(graph, implRoot, SailRepositorySchema.SAILIMPL, sailRoot);
+		addToGraph(graph, sailRoot, SailConfigSchema.SAILTYPE,
+				valueFactory.createLiteral(FederationFactory.SAIL_TYPE));
+		addToGraph(graph, sailRoot, FederationConfig.READ_ONLY, valueFactory.createLiteral(readonly));
+		addToGraph(graph, sailRoot, FederationConfig.DISTINCT, valueFactory.createLiteral(distinct));
+		for (String member : members) {
+			addMember(graph, sailRoot, member);
+		}
+	}
+
+	private void addMember(Model graph, BNode sailRoot, String identifier)
+		throws RDF4JException, MalformedURLException
+	{
+		LOGGER.debug("Adding member: {}", identifier);
+		BNode memberNode = valueFactory.createBNode();
+		addToGraph(graph, sailRoot, FederationConfig.MEMBER, memberNode);
+		String memberRepoType = manager.getRepositoryConfig(identifier).getRepositoryImplConfig().getType();
+		if (!(SPARQLRepositoryFactory.REPOSITORY_TYPE.equals(memberRepoType)
+				|| HTTPRepositoryFactory.REPOSITORY_TYPE.equals(memberRepoType)))
+		{
+			memberRepoType = ProxyRepositoryFactory.REPOSITORY_TYPE;
+		}
+		addToGraph(graph, memberNode, RepositoryConfigSchema.REPOSITORYTYPE,
+				valueFactory.createLiteral(memberRepoType));
+		addToGraph(graph, memberNode, getLocationPredicate(memberRepoType),
+				getMemberLocator(identifier, memberRepoType));
+		LOGGER.debug("Added member {}: ", identifier);
+	}
+
+	private IRI getLocationPredicate(String memberRepoType) {
+		IRI predicate;
+		if (SPARQLRepositoryFactory.REPOSITORY_TYPE.equals(memberRepoType)) {
+			predicate = SPARQLRepositoryConfig.QUERY_ENDPOINT;
+		}
+		else if (HTTPRepositoryFactory.REPOSITORY_TYPE.equals(memberRepoType)) {
+			predicate = HTTPRepositorySchema.REPOSITORYURL;
+		}
+		else {
+			predicate = ProxyRepositorySchema.PROXIED_ID;
+		}
+		return predicate;
+	}
+
+	private Value getMemberLocator(String identifier, String memberRepoType)
+		throws MalformedURLException, RepositoryConfigException, RDF4JException
+	{
+		Value locator;
+		if (HTTPRepositoryFactory.REPOSITORY_TYPE.equals(memberRepoType)) {
+			locator = valueFactory.createIRI(((HTTPRepositoryConfig)manager.getRepositoryConfig(
+					identifier).getRepositoryImplConfig()).getURL());
+		}
+		else if (SPARQLRepositoryFactory.REPOSITORY_TYPE.equals(memberRepoType)) {
+			locator = valueFactory.createIRI(((SPARQLRepositoryConfig)manager.getRepositoryConfig(
+					identifier).getRepositoryImplConfig()).getQueryEndpointUrl());
+		}
+		else {
+			locator = valueFactory.createLiteral(identifier);
+		}
+		return locator;
+	}
+
+	private static void addToGraph(Model graph, Resource subject, IRI predicate, Value object) {
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug(subject + " " + predicate + " " + object);
+		}
+		graph.add(subject, predicate, object);
+	}
+
+}

--- a/federation/src/test/java/org/eclipse/rdf4j/runtime/TestRepositoryManagerFederator.java
+++ b/federation/src/test/java/org/eclipse/rdf4j/runtime/TestRepositoryManagerFederator.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.runtime;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.MalformedURLException;
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
+import org.eclipse.rdf4j.repository.manager.RepositoryManager;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Dale Visser
+ */
+public class TestRepositoryManagerFederator {
+
+	RepositoryManagerFederator federator;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		RepositoryManager manager = mock(RepositoryManager.class);
+		Repository system = mock(Repository.class);
+		when(system.getValueFactory()).thenReturn(SimpleValueFactory.getInstance());
+		when(manager.getSystemRepository()).thenReturn(system);
+		federator = new RepositoryManagerFederator(manager);
+	}
+
+	@Test
+	public final void testDirectRecursiveAddThrowsException()
+		throws MalformedURLException, RDF4JException
+	{
+		thrown.expect(is(instanceOf(RepositoryConfigException.class)));
+		thrown.expectMessage(is(equalTo("A federation member may not have the same ID as the federation.")));
+		String id = "fedtest";
+		federator.addFed(id, "Federation Test", Arrays.asList(new String[] { id, "ignore" }), true, false);
+	}
+
+}

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -157,6 +157,10 @@
 					<groupId>org.eclipse.rdf4j</groupId>
 					<artifactId>rdf4j-rio-turtle</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.eclipse.rdf4j</groupId>
+					<artifactId>rdf4j-repository-manager</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
…and add compliance/model to test SailModel

Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j#960 .

* Move SailModel tests from rdf4j-client to rdf4j-storage
* Move RepositoryManagerFederator from rdf4j-runtime to rdf4j-storage
