### PR TITLE
Fix eclipse/rdf4j#971: Replace order by disk map with serialized queues

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/limited/LimitedSizeEvaluationStrategy.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/limited/LimitedSizeEvaluationStrategy.java
@@ -188,11 +188,16 @@ public class LimitedSizeEvaluationStrategy extends StrictEvaluationStrategy {
 	public CloseableIteration<BindingSet, QueryEvaluationException> evaluate(Order node, BindingSet bindings)
 		throws QueryEvaluationException
 	{
-		ValueComparator vcmp = new ValueComparator();
-		OrderComparator cmp = new OrderComparator(this, node, vcmp);
-		boolean reduced = isReducedOrDistinct(node);
 		long limit = getLimit(node);
-		return new LimitedSizeOrderIteration(evaluate(node.getArg(), bindings), cmp, limit, reduced, used,
-				maxSize);
+		if (maxSize < limit) {
+			ValueComparator vcmp = new ValueComparator();
+			OrderComparator cmp = new OrderComparator(this, node, vcmp);
+			boolean reduced = isReducedOrDistinct(node);
+			return new LimitedSizeOrderIteration(evaluate(node.getArg(), bindings), cmp, limit, reduced, used,
+					maxSize);
+		}
+		else {
+			return super.evaluate(node, bindings);
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j#971 .

* Use in-memory collection until iterationCacheSyncThreshold is reached
* Sort the collection in batches, which performs better with large result sets
