### PR TITLE
Issue eclipse/rdf4j#960: Correct parent compliance pom name

### DIFF
--- a/compliance/model/pom.xml
+++ b/compliance/model/pom.xml
@@ -4,7 +4,7 @@
 
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<artifactId>rdf4j-compliance</artifactId>
+		<artifactId>rdf4j-storage-compliance</artifactId>
 		<version>2.3-SNAPSHOT</version>
 	</parent>
 


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j#960 .

* Update compliance parent pom to storage-compliance
