### PR TITLE
Fix eclipse/rdf4j#974: Check for empty set in union

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/iterator/HashJoinIteration.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
 import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.util.iterators.EmptyIterator;
 
 /**
  * Generic hash join implementation suitable for use by Sail implementations.
@@ -137,8 +138,10 @@ public class HashJoinIteration extends LookAheadIteration<BindingSet, QueryEvalu
 				if (currentScanElem instanceof EmptyBindingSet) {
 					// the empty bindingset should be merged with all bindingset in the
 					// hash table
-					nextHashTableValues = hashTableValues = new UnionIterator<BindingSet>(
-							nextHashTable.values());
+					Collection<List<BindingSet>> values = nextHashTable.values();
+					boolean empty = values.isEmpty() || values.size() == 1 && values.contains(null);
+					nextHashTableValues = hashTableValues = empty ? new EmptyIterator<>()
+							: new UnionIterator<BindingSet>(values);
 					if (!nextHashTableValues.hasNext()) {
 						currentScanElem = null;
 						closeHashValue(nextHashTableValues);


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j#974 .

* Check for empty union condition and iff use EmptyIterator
