### PR TITLE
Fix #55: Don't call begin/endReading as reading is synchronized

### DIFF
--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailConnection.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailConnection.java
@@ -194,19 +194,7 @@ public class LuceneSailConnection extends NotifyingSailConnectionWrapper {
 		throws SailException
 	{
 		if (closed.compareAndSet(false, true)) {
-			try {
-				super.close();
-			}
-			finally {
-				try {
-					luceneIndex.endReading();
-				}
-				catch (IOException e) {
-					logger.warn("could not close IndexReader or IndexSearcher " + e, e);
-				}
-				// remember if you were closed before, some sloppy programmers
-				// may call close() twice.
-			}
+			super.close();
 		}
 	}
 
@@ -426,14 +414,6 @@ public class LuceneSailConnection extends NotifyingSailConnectionWrapper {
 
 		if (closed.get()) {
 			throw new SailException("Sail has been closed already");
-		}
-
-		// mark that reading is in progress
-		try {
-			this.luceneIndex.beginReading();
-		}
-		catch (IOException e) {
-			throw new SailException(e);
 		}
 
 		// evaluate queries, generate binding sets, and remove queries

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchIndex.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchIndex.java
@@ -39,9 +39,11 @@ public interface SearchIndex {
 	Collection<BindingSet> evaluate(SearchQueryEvaluator query)
 		throws SailException;
 
+	@Deprecated
 	void beginReading()
 		throws IOException;
 
+	@Deprecated
 	void endReading()
 		throws IOException;
 

--- a/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/LuceneSpinSailConnection.java
+++ b/lucene-spin/src/main/java/org/eclipse/rdf4j/lucene/spin/LuceneSpinSailConnection.java
@@ -126,18 +126,7 @@ public class LuceneSpinSailConnection extends NotifyingSailConnectionWrapper {
 		throws SailException
 	{
 		if (closed.compareAndSet(false, true)) {
-			try {
-				super.close();
-			}
-			finally {
-				try {
-					luceneIndex.endReading();
-				}
-				catch (IOException e) {
-					logger.warn("could not close IndexReader or IndexSearcher " + e, e);
-					throw new SailException(e);
-				}
-			}
+			super.close();
 		}
 	}
 

--- a/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/DistanceTupleFunction.java
+++ b/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/DistanceTupleFunction.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.rdf4j.sail.lucene.fn;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -25,7 +24,6 @@ import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryContext;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.TupleFunction;
-import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lucene.DistanceQuerySpec;
 import org.eclipse.rdf4j.sail.lucene.LuceneSailSchema;
 import org.eclipse.rdf4j.sail.lucene.SearchIndex;
@@ -89,13 +87,6 @@ public class DistanceTupleFunction implements TupleFunction {
 
 		          SearchIndex luceneIndex = SearchIndexQueryContextInitializer.getSearchIndex(
 				QueryContext.getQueryContext());
-		// mark that reading is in progress
-		try {
-			luceneIndex.beginReading();
-		}
-		catch (IOException e) {
-			throw new SailException(e);
-		}
 		Collection<BindingSet> results = luceneIndex.evaluate((SearchQueryEvaluator)query);
 		return new ConvertingIteration<BindingSet, List<Value>, QueryEvaluationException>(
 				new CloseableIteratorIteration<>(results.iterator()))

--- a/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/QueryTupleFunction.java
+++ b/lucene-spin/src/main/java/org/eclipse/rdf4j/sail/lucene/fn/QueryTupleFunction.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.rdf4j.sail.lucene.fn;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -23,7 +22,6 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryContext;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.TupleFunction;
-import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lucene.LuceneSailSchema;
 import org.eclipse.rdf4j.sail.lucene.QuerySpec;
 import org.eclipse.rdf4j.sail.lucene.SearchIndex;
@@ -104,13 +102,6 @@ public class QueryTupleFunction implements TupleFunction {
 				subject, queryString, propertyURI);
 		SearchIndex luceneIndex = SearchIndexQueryContextInitializer.getSearchIndex(
 				QueryContext.getQueryContext());
-		// mark that reading is in progress
-		try {
-			luceneIndex.beginReading();
-		}
-		catch (IOException e) {
-			throw new SailException(e);
-		}
 		Collection<BindingSet> results = luceneIndex.evaluate((SearchQueryEvaluator)query);
 		return new ConvertingIteration<BindingSet, List<Value>, QueryEvaluationException>(
 				new CloseableIteratorIteration<>(results.iterator()))

--- a/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
+++ b/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
@@ -7,18 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene;
 
-import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.MATCHES;
-import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.QUERY;
-import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.store.RAMDirectory;
-import org.eclipse.rdf4j.query.QueryLanguage;
-import org.eclipse.rdf4j.query.TupleQuery;
-import org.eclipse.rdf4j.query.TupleQueryResult;
-import org.junit.Test;
 
 public class LuceneSailTest extends AbstractGenericLuceneTest {
 
@@ -29,92 +21,5 @@ public class LuceneSailTest extends AbstractGenericLuceneTest {
 	{
 		index = new LuceneIndex(new RAMDirectory(), new StandardAnalyzer());
 		sail.setLuceneIndex(index);
-	}
-
-	/**
-	 * This test simulates possible flow of calls to the LuceneIndex. It assert does InexReader and
-	 * IndexSearcher are not closed while iterating but are finally close.
-	 *
-	 * @throws Exception
-	 */
-	@Test
-	public void testClosingIndexReaderAndSearcherAllCases()
-		throws Exception
-	{
-
-		connection.add(SUBJECT_1, PREDICATE_1, vf.createLiteral("sfourponecone"), CONTEXT_1);
-		connection.add(SUBJECT_2, PREDICATE_1, vf.createLiteral("sfourponecone"), CONTEXT_1);
-		connection.add(SUBJECT_2, PREDICATE_1, vf.createLiteral("sfourponectwo"), CONTEXT_1);
-		connection.add(SUBJECT_2, PREDICATE_1, vf.createLiteral("sfourponectwo"), CONTEXT_1);
-
-		connection.commit();
-		assertEquals(0, index.getOldMonitors().size());
-		assertEquals(null, index.currentMonitor);
-		// prepare the query
-
-		// First search on the LuceneIndex
-		String queryString = "SELECT Resource FROM {Resource} <" + MATCHES + "> {}  <" + QUERY
-				+ "> {\"sfourponecone\"} ";
-		TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SERQL, queryString);
-		TupleQueryResult result1 = query.evaluate();
-
-		assertEquals(0, index.getOldMonitors().size());
-		assertEquals(1, index.currentMonitor.getReadingCount());
-		// check the results is not needed, just assert iterator is not closed
-		// assertTrue(result1.hasNext());
-		// result1.next();
-
-		// Second search on the LuceneIndex
-		queryString = "SELECT Resource FROM {Resource} <" + MATCHES + "> {}  <" + QUERY
-				+ "> {\"sfourponecone\"} ";
-		query = connection.prepareTupleQuery(QueryLanguage.SERQL, queryString);
-		TupleQueryResult result2 = query.evaluate();
-
-		assertEquals(0, index.getOldMonitors().size());
-		assertEquals(2, index.currentMonitor.getReadingCount());
-		// CHECK value of the CurrentReader readersCount
-
-		// check the results is not needed, just assert iterator is not closed
-		// assertTrue(result2.hasNext());
-		// result2.next();
-
-		// CHECK value of the CurrentReader readersCount
-		assertEquals(0, index.getOldMonitors().size());
-		assertEquals(2, index.currentMonitor.getReadingCount());
-
-		// empty commit without changes do not invalidate readers
-		connection.commit();
-
-		// CHECK value of the CurrentReader readersCount
-		assertEquals(0, index.getOldMonitors().size());
-		assertEquals(2, index.currentMonitor.getReadingCount());
-
-		// This should invalidate readers
-		connection.add(SUBJECT_2, PREDICATE_1, vf.createLiteral("sfourponecthree"), CONTEXT_1);
-		connection.commit();
-		// But readers can not be closed, they are being iterated
-		assertEquals(1, index.getOldMonitors().size());
-		assertEquals(null, index.currentMonitor);
-
-		// Third search on the index should create new urrent ReaderMonitor
-		queryString = "SELECT Resource FROM {Resource} <" + MATCHES + "> {}  <" + QUERY
-				+ "> {\"sfourponecone\"} ";
-		query = connection.prepareTupleQuery(QueryLanguage.SERQL, queryString);
-		TupleQueryResult result3 = query.evaluate();
-
-		assertEquals(1, index.getOldMonitors().size());
-		assertEquals(1, index.currentMonitor.getReadingCount());
-
-		// When iteration is finish remove old monitor
-		result1.close();
-		assertEquals(1, index.getOldMonitors().size());
-		result2.close();
-		assertEquals(1, index.getOldMonitors().size());
-		// current monitor is not removed, there is no need
-		result3.close();
-
-		connection.close();
-		assertEquals(0, index.currentMonitor.getReadingCount());
-
 	}
 }


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #55 .

* Deprecate LuceneIndex#beginReading() and LuceneIndex#endReading()
* Those methods keep the index open, but
* The index is only used within synchronized methods of LuceneIndex anyway and can't be closed in those
