### PR TITLE
Fix #62: Create new Lucene IndexWriter after rollback

### DIFF
--- a/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
+++ b/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
@@ -334,7 +334,7 @@ public class LuceneIndex extends AbstractLuceneIndex {
 		if (closed.get()) {
 			throw new SailException("Index has been closed");
 		}
-		if (indexWriter == null) {
+		if (indexWriter == null || !indexWriter.isOpen()) {
 			IndexWriterConfig indexWriterConfig = getIndexWriterConfig();
 			indexWriter = new IndexWriter(directory, indexWriterConfig);
 		}


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #62 .

* Most of time IndexWriter is set to null after being closed
* On Rollback IndexWriter is closed, but not set to null
* Change for null or closed IndexWriter
