### PR TITLE
Fix #64: Include shacl in rdf4j-storage

### DIFF
--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -292,6 +292,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-shacl</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #64 .

* Add rdf4j-shacl to storage/pom.xml
