### PR TITLE
Fix #71: Update Lucene, Solr and Elasticsearch dependencies

### DIFF
--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -16,10 +16,26 @@
 	<description>Tests for Elasticsearch.</description>
 
 	<properties>
-		<lucene.version>6.6.4</lucene.version>
+		<lucene.version>6.6.1</lucene.version>
 		<elasticsearch.version>5.6.9</elasticsearch.version>
 	</properties>
 
+	<!-- disable the Java security manager for elasticsearch tests -->
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.21.0</version>
+				<configuration>
+					<systemPropertyVariables>
+						<tests.security.manager>false</tests.security.manager>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -13,10 +13,10 @@
 	<name>RDF4J Elasticsearch Sail Tests</name>
 	<description>Tests for Elasticsearch.</description>
 
-    <properties>
-        <lucene.version>5.5.4</lucene.version>
-        <elasticsearch.version>2.4.6</elasticsearch.version>
-    </properties>
+	<properties>
+		<lucene.version>6.6.4</lucene.version>
+		<elasticsearch.version>5.6.9</elasticsearch.version>
+	</properties>
 
 	<dependencies>
 		<dependency>
@@ -31,12 +31,11 @@
 		    <version>${lucene.version}</version>
 		    <scope>test</scope>
 		</dependency>
-  		<dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <version>${elasticsearch.version}</version>
+		<dependency>
+			<groupId>org.elasticsearch.test</groupId>
+			<artifactId>framework</artifactId>
+			<version>${elasticsearch.version}</version>
 			<scope>test</scope>
-			<type>test-jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>

--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -26,10 +28,10 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-		    <groupId>org.apache.lucene</groupId>
-		    <artifactId>lucene-test-framework</artifactId>
-		    <version>${lucene.version}</version>
-		    <scope>test</scope>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-test-framework</artifactId>
+			<version>${lucene.version}</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.elasticsearch.test</groupId>
@@ -73,6 +75,12 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>log4j-over-slf4j</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.client</groupId>
+			<artifactId>transport</artifactId>
+			<version>${elasticsearch.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearch;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -15,7 +16,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailGeoSPARQLTest;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.plugin.deletebyquery.DeleteByQueryPlugin;
+import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
@@ -56,8 +57,13 @@ public class ElasticsearchSailGeoSPARQLTest extends ESIntegTestCase {
 	}
 
 	@Override
+	protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+		return Arrays.asList(ReindexPlugin.class);
+	}
+
+	@Override
 	protected Collection<Class<? extends Plugin>> nodePlugins() {
-		return pluginList(DeleteByQueryPlugin.class);
+		return Arrays.asList(ReindexPlugin.class);
 	}
 
 	@After

--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearch;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -15,7 +16,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailIndexedPropertiesTest;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.plugin.deletebyquery.DeleteByQueryPlugin;
+import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
@@ -55,8 +56,13 @@ public class ElasticsearchSailIndexedPropertiesTest extends ESIntegTestCase {
 	}
 
 	@Override
+	protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+		return Arrays.asList(ReindexPlugin.class);
+	}
+
+	@Override
 	protected Collection<Class<? extends Plugin>> nodePlugins() {
-		return pluginList(DeleteByQueryPlugin.class);
+		return Arrays.asList(ReindexPlugin.class);
 	}
 
 	@After

--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearch;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -15,7 +16,7 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailTest;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.plugin.deletebyquery.DeleteByQueryPlugin;
+import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
@@ -55,8 +56,13 @@ public class ElasticsearchSailTest extends ESIntegTestCase {
 	}
 
 	@Override
+	protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+		return Arrays.asList(ReindexPlugin.class);
+	}
+
+	@Override
 	protected Collection<Class<? extends Plugin>> nodePlugins() {
-		return pluginList(DeleteByQueryPlugin.class);
+		return Arrays.asList(ReindexPlugin.class);
 	}
 
 	@After

--- a/compliance/elasticsearch/src/test/java/org/elasticsearch/bootstrap/JarHell.java
+++ b/compliance/elasticsearch/src/test/java/org/elasticsearch/bootstrap/JarHell.java
@@ -1,0 +1,36 @@
+package org.elasticsearch.bootstrap;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * test of elasticsearch pass. Thus as a workaround we deactivate this test. see
+ * https://stackoverflow.com/questions/38712251/java-jar-hell-runtime-exception
+ */
+public class JarHell {
+
+	private JarHell() {
+	}
+
+	public static void checkJarHell()
+		throws Exception
+	{
+	}
+
+	public static void checkJarHell(URL urls[])
+		throws Exception
+	{
+	}
+
+	public static void checkVersionFormat(String targetVersion) {
+	}
+
+	public static void checkJavaVersion(String resource, String targetVersion) {
+	}
+
+	public static Set<URL> parseClassPath() {
+		return Collections.emptySet();
+	}
+
+}

--- a/compliance/solr/pom.xml
+++ b/compliance/solr/pom.xml
@@ -14,7 +14,7 @@
 	<description>Tests for Solr Sail.</description>
 
 	<properties>
-		<solr.version>5.5.4</solr.version>
+		<solr.version>6.6.4</solr.version>
 	</properties>
 
 	<dependencies>

--- a/compliance/solr/pom.xml
+++ b/compliance/solr/pom.xml
@@ -14,7 +14,7 @@
 	<description>Tests for Solr Sail.</description>
 
 	<properties>
-		<solr.version>6.6.4</solr.version>
+		<solr.version>6.6.1</solr.version>
 	</properties>
 
 	<dependencies>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -14,7 +14,7 @@
     <description>StackableSail implementation offering full-text search on literals, based on Elastic Search.</description>
 
     <properties>
-        <elasticsearch.version>2.4.6</elasticsearch.version>
+        <elasticsearch.version>5.6.9</elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -29,10 +29,10 @@
             <artifactId>elasticsearch</artifactId>
             <version>${elasticsearch.version}</version>
         </dependency>
-		<dependency>
-		    <groupId>org.elasticsearch.plugin</groupId>
-		    <artifactId>delete-by-query</artifactId>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>transport</artifactId>
             <version>${elasticsearch.version}</version>
-		</dependency>
+        </dependency>
     </dependencies>
 </project>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -1,38 +1,46 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.eclipse.rdf4j</groupId>
-        <artifactId>rdf4j-storage-parent</artifactId>
-        <version>2.4-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j-storage-parent</artifactId>
+		<version>2.4-SNAPSHOT</version>
+	</parent>
 
-    <artifactId>rdf4j-sail-elasticsearch</artifactId>
+	<artifactId>rdf4j-sail-elasticsearch</artifactId>
 
-    <name>RDF4J Elastic Search Sail Index</name>
-    <description>StackableSail implementation offering full-text search on literals, based on Elastic Search.</description>
+	<name>RDF4J Elastic Search Sail Index</name>
+	<description>StackableSail implementation offering full-text search on literals, based on Elastic Search.</description>
 
-    <properties>
-        <elasticsearch.version>5.6.9</elasticsearch.version>
-    </properties>
+	<properties>
+		<elasticsearch.version>5.6.9</elasticsearch.version>
+	</properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>rdf4j-sail-lucene-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sail-lucene-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <version>${elasticsearch.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>transport</artifactId>
-            <version>${elasticsearch.version}</version>
-        </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.elasticsearch.client</groupId>
+			<artifactId>transport</artifactId>
+			<version>${elasticsearch.version}</version>
+			<optional>true</optional>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
 </project>

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocument.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocument.java
@@ -16,16 +16,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.lucene.spatial.util.GeoHashUtils;
 import org.eclipse.rdf4j.sail.lucene.SearchDocument;
 import org.eclipse.rdf4j.sail.lucene.SearchFields;
+import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.search.SearchHit;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
 
 import com.google.common.base.Function;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
 
 public class ElasticsearchDocument implements SearchDocument {
 

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentDistance.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentDistance.java
@@ -10,14 +10,14 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.sail.lucene.DocumentDistance;
-import org.elasticsearch.common.geo.GeoDistance.FixedSourceDistance;
+import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.unit.DistanceUnit;
 import org.elasticsearch.search.SearchHit;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.distance.DistanceUtils;
 
 import com.google.common.base.Function;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.distance.DistanceUtils;
 
 public class ElasticsearchDocumentDistance extends ElasticsearchDocumentResult implements DocumentDistance {
 
@@ -25,26 +25,27 @@ public class ElasticsearchDocumentDistance extends ElasticsearchDocumentResult i
 
 	private final URI units;
 
-	private final FixedSourceDistance srcDistance;
+	private final GeoPoint srcPoint;
 
 	private final DistanceUnit unit;
 
 	public ElasticsearchDocumentDistance(SearchHit hit,
 			Function<? super String, ? extends SpatialContext> geoContextMapper, String geoPointField,
-			URI units, FixedSourceDistance srcDistance, DistanceUnit unit)
+			URI units, GeoPoint srcPoint, DistanceUnit unit)
 	{
 		super(hit, geoContextMapper);
 		this.geoPointField = geoPointField;
 		this.units = units;
-		this.srcDistance = srcDistance;
+		this.srcPoint = srcPoint;
 		this.unit = unit;
 	}
 
 	@Override
 	public double getDistance() {
 		String geohash = (String)((ElasticsearchDocument)getDocument()).getSource().get(geoPointField);
-		GeoPoint point = GeoPoint.fromGeohash(geohash);
-		double unitDist = srcDistance.calculate(point.getLat(), point.getLon());
+		GeoPoint dstPoint = GeoPoint.fromGeohash(geohash);
+
+		double unitDist = GeoDistance.ARC.calculate(srcPoint.getLat(), srcPoint.getLon(), dstPoint.getLat(), dstPoint.getLon(), unit);
 		double distance;
 		if (GEOF.UOM_METRE.equals(units)) {
 			distance = unit.toMeters(unitDist);

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentDistance.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentDistance.java
@@ -7,7 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.elasticsearch;
 
-import org.eclipse.rdf4j.model.URI;
+
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.sail.lucene.DocumentDistance;
 import org.elasticsearch.common.geo.GeoDistance;
@@ -23,7 +24,7 @@ public class ElasticsearchDocumentDistance extends ElasticsearchDocumentResult i
 
 	private final String geoPointField;
 
-	private final URI units;
+	private final IRI units;
 
 	private final GeoPoint srcPoint;
 
@@ -31,7 +32,7 @@ public class ElasticsearchDocumentDistance extends ElasticsearchDocumentResult i
 
 	public ElasticsearchDocumentDistance(SearchHit hit,
 			Function<? super String, ? extends SpatialContext> geoContextMapper, String geoPointField,
-			URI units, GeoPoint srcPoint, DistanceUnit unit)
+			IRI units, GeoPoint srcPoint, DistanceUnit unit)
 	{
 		super(hit, geoContextMapper);
 		this.geoPointField = geoPointField;

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentResult.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentResult.java
@@ -10,9 +10,9 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 import org.eclipse.rdf4j.sail.lucene.DocumentResult;
 import org.eclipse.rdf4j.sail.lucene.SearchDocument;
 import org.elasticsearch.search.SearchHit;
+import org.locationtech.spatial4j.context.SpatialContext;
 
 import com.google.common.base.Function;
-import com.spatial4j.core.context.SpatialContext;
 
 public class ElasticsearchDocumentResult implements DocumentResult {
 

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentScore.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchDocumentScore.java
@@ -13,11 +13,11 @@ import org.eclipse.rdf4j.sail.lucene.DocumentScore;
 import org.eclipse.rdf4j.sail.lucene.SearchFields;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.highlight.HighlightField;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
+import org.locationtech.spatial4j.context.SpatialContext;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.spatial4j.core.context.SpatialContext;
 
 public class ElasticsearchDocumentScore extends ElasticsearchDocumentResult implements DocumentScore {
 

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.lucene.spatial.util.GeoHashUtils;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
@@ -37,8 +36,6 @@ import org.eclipse.rdf4j.sail.lucene.SearchQuery;
 import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
-import org.elasticsearch.action.deletebyquery.DeleteByQueryAction;
-import org.elasticsearch.action.deletebyquery.DeleteByQueryRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -50,8 +47,7 @@ import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.health.ClusterIndexHealth;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
-import org.elasticsearch.common.geo.GeoDistance;
-import org.elasticsearch.common.geo.GeoDistance.FixedSourceDistance;
+import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -66,20 +62,26 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
-import org.elasticsearch.plugin.deletebyquery.DeleteByQueryPlugin;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.context.SpatialContextFactory;
+import org.locationtech.spatial4j.distance.DistanceUtils;
+import org.locationtech.spatial4j.io.GeohashUtils;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.Iterables;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.context.SpatialContextFactory;
-import com.spatial4j.core.distance.DistanceUtils;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
+
 
 /**
  * Requires an Elasticsearch cluster with the DeleteByQuery plugin.
@@ -202,8 +204,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 			}
 		}
 
-		client = TransportClient.builder().settings(settingsBuilder).addPlugin(
-				DeleteByQueryPlugin.class).build();
+		client = new PreBuiltTransportClient(settingsBuilder.build());
 		String transport = parameters.getProperty(TRANSPORT_KEY, DEFAULT_TRANSPORT);
 		for (String addrStr : transport.split(",")) {
 			TransportAddress addr;
@@ -253,7 +254,8 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		}
 		String waitForRelocatingShards = parameters.getProperty(WAIT_FOR_RELOCATING_SHARDS_KEY);
 		if (waitForRelocatingShards != null) {
-			healthReqBuilder.setWaitForRelocatingShards(Integer.parseInt(waitForRelocatingShards));
+			// TODO no longer available
+//			healthReqBuilder.setWaitForRelocatingShards(Integer.parseInt(waitForRelocatingShards));
 		}
 		ClusterHealthResponse healthResponse = healthReqBuilder.execute().actionGet();
 		logger.info("Cluster health: {}", healthResponse.getStatus());
@@ -266,9 +268,10 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 				indexHealth.getNumberOfShards(), indexHealth.getActiveShards(),
 				indexHealth.getActivePrimaryShards(), indexHealth.getInitializingShards(),
 				indexHealth.getUnassignedShards(), indexHealth.getRelocatingShards());
-		for (String err : healthResponse.getValidationFailures()) {
-			logger.warn(err);
-		}
+//		TODO no longer available
+//		for (String err : healthResponse.getValidationFailures()) {
+//			logger.warn(err);
+//		}
 	}
 
 	protected Function<? super String, ? extends SpatialContext> createSpatialContextMapper(
@@ -299,7 +302,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 								analyzer).endObject().endObject().endObject().endObject().string();
 
 		doAcknowledgedRequest(client.admin().indices().prepareCreate(indexName).setSettings(
-				Settings.settingsBuilder().loadFromSource(settings)));
+				Settings.builder().loadFromSource(settings)));
 
 		// use _source instead of explicit stored = true
 		XContentBuilder typeMapping = XContentFactory.jsonBuilder();
@@ -547,22 +550,24 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		QueryBuilder qb = prepareQuery(propertyURI, QueryBuilders.queryStringQuery(query));
 		SearchRequestBuilder request = client.prepareSearch();
 		if (highlight) {
+			HighlightBuilder hb = new HighlightBuilder();
 			String field;
 			if(propertyURI != null) {
 				field = toPropertyFieldName(SearchFields.getPropertyField(propertyURI));
 			} else {
 				field = ALL_PROPERTY_FIELDS;
-				request.setHighlighterRequireFieldMatch(false);
+				hb.requireFieldMatch(false);
 			}
-			request.addHighlightedField(field);
-			request.setHighlighterPreTags(SearchFields.HIGHLIGHTER_PRE_TAG);
-			request.setHighlighterPostTags(SearchFields.HIGHLIGHTER_POST_TAG);
+			hb.field(field);
+			hb.preTags(SearchFields.HIGHLIGHTER_PRE_TAG);
+			hb.postTags(SearchFields.HIGHLIGHTER_POST_TAG);
 			// Elastic Search doesn't really have the same support for fragments as
 			// Lucene.
 			// So, we have to get back the whole highlighted value (comma-separated
 			// if it is a list)
 			// and then post-process it into fragments ourselves.
-			request.setHighlighterNumOfFragments(0);
+			hb.numOfFragments(0);
+			request.highlighter(hb);
 		}
 
 		SearchHits hits;
@@ -639,8 +644,8 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		double lon = p.getX();
 		final String fieldName = toGeoPointFieldName(SearchFields.getPropertyField(geoProperty));
 		QueryBuilder qb = QueryBuilders.functionScoreQuery(
-				QueryBuilders.geoDistanceQuery(fieldName).lat(lat).lon(lon).distance(unitDist, unit),
-				ScoreFunctionBuilders.linearDecayFunction(fieldName, GeoHashUtils.stringEncode(lon, lat),
+				QueryBuilders.geoDistanceQuery(fieldName).point(lat, lon).distance(unitDist, unit),
+				ScoreFunctionBuilders.linearDecayFunction(fieldName, GeohashUtils.encodeLatLon(lat, lon),
 						new DistanceUnit.Distance(unitDist, unit)));
 		if (contextVar != null) {
 			qb = addContextTerm(qb, (Resource)contextVar.getValue());
@@ -648,12 +653,12 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 
 		SearchRequestBuilder request = client.prepareSearch();
 		SearchHits hits = search(request, qb);
-		final FixedSourceDistance srcDistance = GeoDistance.DEFAULT.fixedSourceDistance(lat, lon, unit);
+		final GeoPoint srcPoint = new GeoPoint(lat, lon);
 		return Iterables.transform(hits, new Function<SearchHit, DocumentDistance>() {
 
 			@Override
 			public DocumentDistance apply(SearchHit hit) {
-				return new ElasticsearchDocumentDistance(hit, geoContextMapper, fieldName, units, srcDistance,
+				return new ElasticsearchDocumentDistance(hit, geoContextMapper, fieldName, units, srcPoint,
 						unit);
 			}
 		});
@@ -686,14 +691,15 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		}
 		final String fieldName = toGeoShapeFieldName(SearchFields.getPropertyField(geoProperty));
 		GeoShapeQueryBuilder fb = QueryBuilders.geoShapeQuery(fieldName,
-				ElasticsearchSpatialSupport.getSpatialSupport().toShapeBuilder(shape), spatialOp);
+				ElasticsearchSpatialSupport.getSpatialSupport().toShapeBuilder(shape));
+		fb.relation(spatialOp);
 		QueryBuilder qb = QueryBuilders.matchAllQuery();
 		if (contextVar != null) {
 			qb = addContextTerm(qb, (Resource)contextVar.getValue());
 		}
 
 		SearchRequestBuilder request = client.prepareSearch();
-		SearchHits hits = search(request, QueryBuilders.filteredQuery(qb, fb));
+		SearchHits hits = search(request, QueryBuilders.boolQuery().must(qb).filter(fb));
 		return Iterables.transform(hits, new Function<SearchHit, DocumentResult>() {
 
 			@Override
@@ -726,8 +732,8 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 			nDocs = maxDocs;
 		}
 		else {
-			long docCount = client.prepareCount(indexName).setTypes(types).setQuery(
-					query).execute().actionGet().getCount();
+			long docCount = client.prepareSearch(indexName).setTypes(types).setSource(
+					new SearchSourceBuilder().size(0).query(query)).get().getHits().getTotalHits();
 			nDocs = Math.max((int)Math.min(docCount, Integer.MAX_VALUE), 1);
 		}
 		SearchResponse response = request.setIndices(indexName).setTypes(types).setVersion(true).setQuery(
@@ -816,10 +822,8 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 			// }
 
 			// now delete all documents from the deleted context
-			new DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE).setIndices(
-					indexName).setQuery(
-							QueryBuilders.termQuery(
-					SearchFields.CONTEXT_FIELD_NAME, contextString)).execute().actionGet();
+			DeleteByQueryAction.INSTANCE.newRequestBuilder(client).source(indexName).filter(
+					QueryBuilders.termQuery(SearchFields.CONTEXT_FIELD_NAME, contextString)).get();
 		}
 
 		// now add those again, that had other contexts also.
@@ -892,7 +896,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		throws IOException
 	{
 		IndexResponse response = request.execute().actionGet();
-		boolean ok = response.isCreated();
+		boolean ok = response.status().equals(RestStatus.CREATED);
 		if (!ok) {
 			throw new IOException("Document not created: " + request.get().getClass().getName());
 		}
@@ -903,7 +907,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		throws IOException
 	{
 		UpdateResponse response = request.execute().actionGet();
-		boolean isUpsert = response.isCreated();
+		boolean isUpsert = response.status().equals(RestStatus.CREATED);
 		if (isUpsert) {
 			throw new IOException("Unexpected upsert: " + request.get().getClass().getName());
 		}

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -18,8 +18,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.algebra.Var;
@@ -526,7 +526,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 	 */
 	@Override
 	@Deprecated
-	protected SearchQuery parseQuery(String query, URI propertyURI)
+	protected SearchQuery parseQuery(String query, IRI propertyURI)
 		throws MalformedQueryException
 	{
 		QueryBuilder qb = prepareQuery(propertyURI, QueryBuilders.queryStringQuery(query));
@@ -543,7 +543,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 	 *         when the parsing brakes
 	 */
 	@Override
-	protected Iterable<? extends DocumentScore> query(Resource subject, String query, URI propertyURI,
+	protected Iterable<? extends DocumentScore> query(Resource subject, String query, IRI propertyURI,
 			boolean highlight)
 		throws MalformedQueryException, IOException
 	{
@@ -614,7 +614,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 	}
 
 	@Override
-	protected Iterable<? extends DocumentDistance> geoQuery(final URI geoProperty, Point p, final URI units,
+	protected Iterable<? extends DocumentDistance> geoQuery(final IRI geoProperty, Point p, final IRI units,
 			double distance, String distanceVar, Var contextVar)
 		throws MalformedQueryException, IOException
 	{
@@ -681,7 +681,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 	}
 
 	@Override
-	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, URI geoProperty,
+	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, IRI geoProperty,
 			Shape shape, Var contextVar)
 		throws MalformedQueryException, IOException
 	{
@@ -741,7 +741,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		return response.getHits();
 	}
 
-	private QueryStringQueryBuilder prepareQuery(URI propertyURI, QueryStringQueryBuilder query) {
+	private QueryStringQueryBuilder prepareQuery(IRI propertyURI, QueryStringQueryBuilder query) {
 		// check out which query parser to use, based on the given property URI
 		if (propertyURI == null)
 			// if we have no property given, we create a default query parser which

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndex.java
@@ -130,8 +130,19 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 	 * Set the parameter "waitForRelocatingShards=" to configure if {@link #initialize(java.util.Properties)
 	 * initialization} should wait until the specified number of nodes are relocating. Does not wait by
 	 * default.
+	 * 
+	 * @deprecated use {@link #WAIT_FOR_NO_RELOCATING_SHARDS_KEY} in elastic search >= 5.x
 	 */
+	@Deprecated
 	public static final String WAIT_FOR_RELOCATING_SHARDS_KEY = "waitForRelocatingShards";
+
+	/**
+	 * Set the parameter "waitForNoRelocatingShards=true|false" to configure if
+	 * {@link #initialize(java.util.Properties) initialization} should wait until the are no relocating
+	 * shards. Defaults to false, meaning the operation does not wait on there being no more relocating
+	 * shards. Set to true to wait until the number of relocating shards in the cluster is 0.
+	 */
+	public static final String WAIT_FOR_NO_RELOCATING_SHARDS_KEY = "waitForNoRelocatingShards";
 
 	public static final String DEFAULT_INDEX_NAME = "elastic-search-sail";
 
@@ -182,6 +193,7 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		return new String[] { documentType };
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void initialize(Properties parameters)
 		throws Exception
@@ -254,8 +266,12 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 		}
 		String waitForRelocatingShards = parameters.getProperty(WAIT_FOR_RELOCATING_SHARDS_KEY);
 		if (waitForRelocatingShards != null) {
-			// TODO no longer available
-//			healthReqBuilder.setWaitForRelocatingShards(Integer.parseInt(waitForRelocatingShards));
+			logger.warn("Property " + WAIT_FOR_RELOCATING_SHARDS_KEY + " no longer supported. Use "
+					+ WAIT_FOR_NO_RELOCATING_SHARDS_KEY + " instead");
+		}
+		String waitForNoRelocatingShards = parameters.getProperty(WAIT_FOR_NO_RELOCATING_SHARDS_KEY);
+		if (waitForNoRelocatingShards != null) {
+			healthReqBuilder.setWaitForNoRelocatingShards(Boolean.parseBoolean(waitForNoRelocatingShards));
 		}
 		ClusterHealthResponse healthResponse = healthReqBuilder.execute().actionGet();
 		logger.info("Cluster health: {}", healthResponse.getStatus());
@@ -268,10 +284,6 @@ public class ElasticsearchIndex extends AbstractSearchIndex {
 				indexHealth.getNumberOfShards(), indexHealth.getActiveShards(),
 				indexHealth.getActivePrimaryShards(), indexHealth.getInitializingShards(),
 				indexHealth.getUnassignedShards(), indexHealth.getRelocatingShards());
-//		TODO no longer available
-//		for (String err : healthResponse.getValidationFailures()) {
-//			logger.warn(err);
-//		}
 	}
 
 	protected Function<? super String, ? extends SpatialContext> createSpatialContextMapper(

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchQuery.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchQuery.java
@@ -9,8 +9,8 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 
 import java.io.IOException;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.sail.lucene.DocumentScore;
 import org.eclipse.rdf4j.sail.lucene.SearchFields;
 import org.eclipse.rdf4j.sail.lucene.SearchQuery;
@@ -65,7 +65,7 @@ public class ElasticsearchQuery implements SearchQuery {
 	 * Highlights the given field or all fields if null.
 	 */
 	@Override
-	public void highlight(URI property) {
+	public void highlight(IRI property) {
 		String field = (property != null)
 				? ElasticsearchIndex.toPropertyFieldName(SearchFields.getPropertyField(property)) : ElasticsearchIndex.ALL_PROPERTY_FIELDS;
 		HighlightBuilder hb = new HighlightBuilder();

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchQuery.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchQuery.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -67,12 +68,14 @@ public class ElasticsearchQuery implements SearchQuery {
 	public void highlight(URI property) {
 		String field = (property != null)
 				? ElasticsearchIndex.toPropertyFieldName(SearchFields.getPropertyField(property)) : ElasticsearchIndex.ALL_PROPERTY_FIELDS;
-		request.addHighlightedField(field);
-		request.setHighlighterPreTags(SearchFields.HIGHLIGHTER_PRE_TAG);
-		request.setHighlighterPostTags(SearchFields.HIGHLIGHTER_POST_TAG);
+		HighlightBuilder hb = new HighlightBuilder();
+		hb.field(field);
+		hb.preTags(SearchFields.HIGHLIGHTER_PRE_TAG);
+		hb.postTags(SearchFields.HIGHLIGHTER_POST_TAG);
 		// Elastic Search doesn't really have the same support for fragments as Lucene.
 		// So, we have to get back the whole highlighted value (comma-separated if it is a list)
 		// and then post-process it into fragments ourselves.
-		request.setHighlighterNumOfFragments(0);
+		hb.numOfFragments(0);
+		request.highlighter(hb);
 	}
 }

--- a/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSpatialSupport.java
+++ b/elasticsearch/src/main/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSpatialSupport.java
@@ -10,8 +10,7 @@ package org.eclipse.rdf4j.sail.elasticsearch;
 import java.util.Map;
 
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * This class will try to load a subclass of itself called

--- a/geosparql/pom.xml
+++ b/geosparql/pom.xml
@@ -20,7 +20,7 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.spatial4j</groupId>
+			<groupId>org.locationtech.spatial4j</groupId>
 			<artifactId>spatial4j</artifactId>
 		</dependency>
 

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Boundary.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Boundary.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:boundary, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Buffer.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Buffer.java
@@ -16,9 +16,8 @@ import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:buffer, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/ConvexHull.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/ConvexHull.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:convexHull, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultSpatialAlgebra.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultSpatialAlgebra.java
@@ -10,11 +10,11 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import java.util.Arrays;
 import java.util.Collections;
 
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.ShapeCollection;
-import com.spatial4j.core.shape.SpatialRelation;
-import com.spatial4j.core.shape.impl.BufferedLineString;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.ShapeCollection;
+import org.locationtech.spatial4j.shape.SpatialRelation;
+import org.locationtech.spatial4j.shape.impl.BufferedLineString;
 
 final class DefaultSpatialAlgebra implements SpatialAlgebra {
 

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultWktWriter.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultWktWriter.java
@@ -9,10 +9,10 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import java.io.IOException;
 
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.ShapeCollection;
-import com.spatial4j.core.shape.impl.BufferedLineString;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.ShapeCollection;
+import org.locationtech.spatial4j.shape.impl.BufferedLineString;
 
 final class DefaultWktWriter implements WktWriter {
 

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Difference.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Difference.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:difference, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Distance.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Distance.java
@@ -13,9 +13,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Point;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Point;
 
 /**
  * The GeoSPARQL {@link Function} geof:distance, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhContains.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhContains.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehContains, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCoveredBy.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCoveredBy.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehCoveredBy, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCovers.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCovers.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehCovers, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhDisjoint.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhDisjoint.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehDisjoint, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhEquals.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhEquals.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehEquals, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhInside.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhInside.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehInside, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhMeet.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhMeet.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehMeet, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhOverlap.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhOverlap.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:ehOverlap, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Envelope.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Envelope.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:envelope, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/FunctionArguments.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/FunctionArguments.java
@@ -17,11 +17,10 @@ import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.distance.DistanceUtils;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.distance.DistanceUtils;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
 
 class FunctionArguments {
 

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunction.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunction.java
@@ -14,9 +14,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 abstract class GeometricBinaryFunction implements Function {
 

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunction.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunction.java
@@ -11,9 +11,8 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 abstract class GeometricRelationFunction implements Function {
 

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunction.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunction.java
@@ -14,9 +14,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 abstract class GeometricUnaryFunction implements Function {
 

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Intersection.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Intersection.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:intersection, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8DC.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8DC.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8dc, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EC.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EC.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8ec, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EQ.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EQ.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8eq, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPP.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPP.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8ntpp, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPPI.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPPI.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8ntppi, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8PO.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8PO.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8po, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPP.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPP.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8tpp, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPPI.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPPI.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:rcc8tppi, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Relate.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Relate.java
@@ -12,9 +12,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:relate, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfContains.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfContains.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfContains, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfCrosses.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfCrosses.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfCrosses, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfDisjoint.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfDisjoint.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfDisjoint, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfEquals.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfEquals.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfEquals, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfIntersects.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfIntersects.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfIntersects, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfOverlaps.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfOverlaps.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfOverlaps, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfTouches.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfTouches.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfTouches, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfWithin.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfWithin.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:sfWithin, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialAlgebra.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialAlgebra.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 public interface SpatialAlgebra {
 

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialSupport.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialSupport.java
@@ -10,8 +10,8 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.context.SpatialContextFactory;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.context.SpatialContextFactory;
 
 /**
  * This class is responsible for creating the {@link com.spatial4j.core.context.SpatialContext},

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SymmetricDifference.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SymmetricDifference.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:symDifference, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Union.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Union.java
@@ -9,8 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
-
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 /**
  * The GeoSPARQL {@link Function} geof:union, as defined in

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/WktWriter.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/WktWriter.java
@@ -9,7 +9,7 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import java.io.IOException;
 
-import com.spatial4j.core.shape.Shape;
+import org.locationtech.spatial4j.shape.Shape;
 
 public interface WktWriter {
 

--- a/lucene-api/pom.xml
+++ b/lucene-api/pom.xml
@@ -34,7 +34,7 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.spatial4j</groupId>
+			<groupId>org.locationtech.spatial4j</groupId>
 			<artifactId>spatial4j</artifactId>
 		</dependency>
 		<dependency>

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractSearchIndex.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractSearchIndex.java
@@ -36,15 +36,15 @@ import org.eclipse.rdf4j.query.algebra.Var;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lucene.util.MapOfListMaps;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
 
 public abstract class AbstractSearchIndex implements SearchIndex {
 

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractSearchIndex.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractSearchIndex.java
@@ -24,7 +24,6 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.BooleanLiteral;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -874,18 +873,18 @@ public abstract class AbstractSearchIndex implements SearchIndex {
 	 * To be removed.
 	 */
 	@Deprecated
-	protected abstract SearchQuery parseQuery(String q, URI property)
+	protected abstract SearchQuery parseQuery(String q, IRI property)
 		throws MalformedQueryException;
 
-	protected abstract Iterable<? extends DocumentScore> query(Resource subject, String q, URI property,
+	protected abstract Iterable<? extends DocumentScore> query(Resource subject, String q, IRI property,
 			boolean highlight)
 		throws MalformedQueryException, IOException;
 
-	protected abstract Iterable<? extends DocumentDistance> geoQuery(URI geoProperty, Point p, URI units,
+	protected abstract Iterable<? extends DocumentDistance> geoQuery(IRI geoProperty, Point p, IRI units,
 			double distance, String distanceVar, Var context)
 		throws MalformedQueryException, IOException;
 
-	protected abstract Iterable<? extends DocumentResult> geoRelationQuery(String relation, URI geoProperty,
+	protected abstract Iterable<? extends DocumentResult> geoRelationQuery(String relation, IRI geoProperty,
 			Shape shape, Var context)
 		throws MalformedQueryException, IOException;
 

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/GeoRelationQuerySpecBuilder.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/GeoRelationQuerySpecBuilder.java
@@ -12,8 +12,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.BindingSet;
@@ -26,7 +26,7 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.ValueConstant;
 import org.eclipse.rdf4j.query.algebra.ValueExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
-import org.eclipse.rdf4j.query.algebra.helpers.QueryModelVisitorBase;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.sail.SailException;
 
 public class GeoRelationQuerySpecBuilder implements SearchQueryInterpreter {
@@ -43,7 +43,7 @@ public class GeoRelationQuerySpecBuilder implements SearchQueryInterpreter {
 		throws SailException
 	{
 
-		tupleExpr.visit(new QueryModelVisitorBase<SailException>() {
+		tupleExpr.visit(new AbstractQueryModelVisitor<SailException>() {
 
 			final Map<String, GeoRelationQuerySpec> specs = new HashMap<String, GeoRelationQuerySpec>();
 
@@ -92,7 +92,7 @@ public class GeoRelationQuerySpecBuilder implements SearchQueryInterpreter {
 
 			@Override
 			public void meet(StatementPattern sp) {
-				URI propertyName = (URI)sp.getPredicateVar().getValue();
+				IRI propertyName = (IRI)sp.getPredicateVar().getValue();
 				if (propertyName != null && index.isGeoField(SearchFields.getPropertyField(propertyName))
 						&& !sp.getObjectVar().hasValue())
 				{

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailConnection.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSailConnection.java
@@ -105,6 +105,7 @@ public class LuceneSailConnection extends NotifyingSailConnectionWrapper {
 
 	private final SearchIndex luceneIndex;
 
+	@SuppressWarnings("unused")
 	private final AbstractFederatedServiceResolver tupleFunctionServiceResolver;
 
 	private final LuceneSail sail;

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilder.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilder.java
@@ -65,6 +65,7 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 	 * a TupleExpr. To be removed, prefer {@link process(TupleExpr tupleExpr, BindingSet bindings, Collection
 	 * <SearchQueryEvaluator> result)}.
 	 */
+	@SuppressWarnings("unchecked")
 	@Deprecated
 	public Set<QuerySpec> process(TupleExpr tupleExpr, BindingSet bindings)
 		throws SailException

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchFields.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchFields.java
@@ -11,13 +11,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.ValueFactoryImpl;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 
 public final class SearchFields {
@@ -66,7 +66,7 @@ public final class SearchFields {
 	public static final Pattern HIGHLIGHTER_PATTERN = Pattern.compile(
 			"(" + HIGHLIGHTER_PRE_TAG + ".+?" + HIGHLIGHTER_POST_TAG + ")");
 
-	private static final ValueFactory valueFactory = ValueFactoryImpl.getInstance();
+	private static final ValueFactory valueFactory = SimpleValueFactory.getInstance();
 
 	private SearchFields() {
 	}
@@ -76,7 +76,7 @@ public final class SearchFields {
 	 * bnode prefixed with a "!".
 	 */
 	public static String getResourceID(Resource resource) {
-		if (resource instanceof URI) {
+		if (resource instanceof IRI) {
 			return resource.toString();
 		}
 		else if (resource instanceof BNode) {
@@ -134,7 +134,7 @@ public final class SearchFields {
 		}
 	}
 
-	public static String getPropertyField(URI property) {
+	public static String getPropertyField(IRI property) {
 		return property.toString();
 	}
 

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchQuery.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/SearchQuery.java
@@ -9,8 +9,8 @@ package org.eclipse.rdf4j.sail.lucene;
 
 import java.io.IOException;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.URI;
 
 @Deprecated
 public interface SearchQuery {
@@ -24,5 +24,5 @@ public interface SearchQuery {
 	/**
 	 * Highlights the given field or all fields if null.
 	 */
-	void highlight(URI property);
+	void highlight(IRI property);
 }

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/util/GeoUnits.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/util/GeoUnits.java
@@ -9,8 +9,8 @@ package org.eclipse.rdf4j.sail.lucene.util;
 
 import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
+import org.locationtech.spatial4j.distance.DistanceUtils;
 
-import com.spatial4j.core.distance.DistanceUtils;
 
 public final class GeoUnits {
 

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/util/GeoUnits.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/util/GeoUnits.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lucene.util;
 
-import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.locationtech.spatial4j.distance.DistanceUtils;
 
@@ -17,7 +17,7 @@ public final class GeoUnits {
 	private GeoUnits() {
 	}
 
-	public static final double toMiles(double distance, URI units) {
+	public static final double toMiles(double distance, IRI units) {
 		final double miles;
 		if (GEOF.UOM_METRE.equals(units)) {
 			miles = DistanceUtils.KM_TO_MILES * distance / 1000.0;
@@ -37,7 +37,7 @@ public final class GeoUnits {
 		return miles;
 	}
 
-	public static final double fromMiles(double miles, URI units) {
+	public static final double fromMiles(double miles, IRI units) {
 		double dist;
 		if (GEOF.UOM_METRE.equals(units)) {
 			dist = DistanceUtils.MILES_TO_KM * miles * 1000.0;
@@ -57,7 +57,7 @@ public final class GeoUnits {
 		return dist;
 	}
 
-	public static final double toKilometres(double distance, URI units) {
+	public static final double toKilometres(double distance, IRI units) {
 		final double kms;
 		if (GEOF.UOM_METRE.equals(units)) {
 			kms = distance / 1000.0;
@@ -77,7 +77,7 @@ public final class GeoUnits {
 		return kms;
 	}
 
-	public static final double fromKilometres(double kms, URI units) {
+	public static final double fromKilometres(double kms, IRI units) {
 		double dist;
 		if (GEOF.UOM_METRE.equals(units)) {
 			dist = kms * 1000.0;
@@ -97,7 +97,7 @@ public final class GeoUnits {
 		return dist;
 	}
 
-	public static final double toDegrees(double distance, URI units) {
+	public static final double toDegrees(double distance, IRI units) {
 		final double degs;
 		if (GEOF.UOM_METRE.equals(units)) {
 			degs = DistanceUtils.dist2Degrees(distance / 1000.0, DistanceUtils.EARTH_MEAN_RADIUS_KM);
@@ -117,7 +117,7 @@ public final class GeoUnits {
 		return degs;
 	}
 
-	public static final double fromDegrees(double degs, URI units) {
+	public static final double fromDegrees(double degs, IRI units) {
 		double dist;
 		if (GEOF.UOM_METRE.equals(units)) {
 			dist = DistanceUtils.degrees2Dist(degs, DistanceUtils.EARTH_MEAN_RADIUS_KM) * 1000.0;

--- a/lucene/pom.xml
+++ b/lucene/pom.xml
@@ -15,7 +15,7 @@
 	<description>StackableSail implementation offering full-text search on literals, based on Apache Lucene.</description>
 
 	<properties>
-		<lucene.version>6.6.4</lucene.version>
+		<lucene.version>6.6.1</lucene.version>
 	</properties>
 
 	<dependencies>

--- a/lucene/pom.xml
+++ b/lucene/pom.xml
@@ -54,13 +54,19 @@
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-spatial</artifactId>
 			<version>${lucene.version}</version>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-spatial-extras</artifactId>
 			<version>${lucene.version}</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-backward-codecs</artifactId>
+			<version>${lucene.version}</version>
+		</dependency>
+		
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/lucene/pom.xml
+++ b/lucene/pom.xml
@@ -15,7 +15,7 @@
 	<description>StackableSail implementation offering full-text search on literals, based on Apache Lucene.</description>
 
 	<properties>
-		<lucene.version>5.5.4</lucene.version>
+		<lucene.version>6.6.4</lucene.version>
 	</properties>
 
 	<dependencies>
@@ -53,6 +53,11 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-spatial</artifactId>
+			<version>${lucene.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-spatial-extras</artifactId>
 			<version>${lucene.version}</version>
 		</dependency>
 

--- a/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocument.java
+++ b/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocument.java
@@ -16,9 +16,9 @@ import java.util.Set;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.spatial.SpatialStrategy;
+import org.locationtech.spatial4j.shape.Shape;
 
 import com.google.common.base.Function;
-import com.spatial4j.core.shape.Shape;
 
 public class LuceneDocument implements SearchDocument {
 

--- a/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocumentDistance.java
+++ b/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocumentDistance.java
@@ -14,10 +14,10 @@ import java.util.Set;
 import org.apache.lucene.search.ScoreDoc;
 import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.sail.lucene.util.GeoUnits;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
 
 import com.google.common.collect.Sets;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Shape;
 
 public class LuceneDocumentDistance extends LuceneDocumentResult implements DocumentDistance {
 

--- a/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocumentDistance.java
+++ b/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneDocumentDistance.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.lucene.search.ScoreDoc;
-import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sail.lucene.util.GeoUnits;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Shape;
@@ -23,7 +23,7 @@ public class LuceneDocumentDistance extends LuceneDocumentResult implements Docu
 
 	private final String geoProperty;
 
-	private final URI units;
+	private final IRI units;
 
 	private final Point origin;
 
@@ -35,7 +35,7 @@ public class LuceneDocumentDistance extends LuceneDocumentResult implements Docu
 		return fields;
 	}
 
-	public LuceneDocumentDistance(ScoreDoc doc, String geoProperty, URI units, Point origin,
+	public LuceneDocumentDistance(ScoreDoc doc, String geoProperty, IRI units, Point origin,
 			boolean includeContext, LuceneIndex index)
 	{
 		super(doc, index, requiredFields(geoProperty, includeContext));

--- a/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
+++ b/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneIndex.java
@@ -72,8 +72,8 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.RAMDirectory;
 import org.apache.lucene.util.Bits;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.algebra.Var;
@@ -756,7 +756,7 @@ public class LuceneIndex extends AbstractLuceneIndex {
 	 */
 	@Override
 	@Deprecated
-	protected SearchQuery parseQuery(String query, URI propertyURI)
+	protected SearchQuery parseQuery(String query, IRI propertyURI)
 		throws MalformedQueryException
 	{
 		Query q;
@@ -779,7 +779,7 @@ public class LuceneIndex extends AbstractLuceneIndex {
 	 *         when the parsing brakes
 	 */
 	@Override
-	protected Iterable<? extends DocumentScore> query(Resource subject, String query, URI propertyURI,
+	protected Iterable<? extends DocumentScore> query(Resource subject, String query, IRI propertyURI,
 			boolean highlight)
 		throws MalformedQueryException, IOException
 	{
@@ -818,7 +818,7 @@ public class LuceneIndex extends AbstractLuceneIndex {
 	}
 
 	@Override
-	protected Iterable<? extends DocumentDistance> geoQuery(final URI geoProperty, Point p, final URI units,
+	protected Iterable<? extends DocumentDistance> geoQuery(final IRI geoProperty, Point p, final IRI units,
 			double distance, String distanceVar, Var contextVar)
 		throws MalformedQueryException, IOException
 	{
@@ -855,7 +855,7 @@ public class LuceneIndex extends AbstractLuceneIndex {
 	}
 
 	@Override
-	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, URI geoProperty,
+	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, IRI geoProperty,
 			Shape shape, Var contextVar)
 		throws MalformedQueryException, IOException
 	{
@@ -988,7 +988,7 @@ public class LuceneIndex extends AbstractLuceneIndex {
 		return getIndexSearcher().search(query, nDocs);
 	}
 
-	private QueryParser getQueryParser(URI propertyURI) {
+	private QueryParser getQueryParser(IRI propertyURI) {
 		// check out which query parser to use, based on the given property URI
 		if (propertyURI == null)
 			// if we have no property given, we create a default query parser

--- a/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneQuery.java
+++ b/lucene/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneQuery.java
@@ -17,8 +17,8 @@ import org.apache.lucene.search.highlight.Formatter;
 import org.apache.lucene.search.highlight.Highlighter;
 import org.apache.lucene.search.highlight.QueryScorer;
 import org.apache.lucene.search.highlight.SimpleHTMLFormatter;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.URI;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -64,7 +64,7 @@ public class LuceneQuery implements SearchQuery {
 
 	@Override
 	@Deprecated
-	public void highlight(URI property) {
+	public void highlight(IRI property) {
 		Formatter formatter = new SimpleHTMLFormatter(SearchFields.HIGHLIGHTER_PRE_TAG,
 				SearchFields.HIGHLIGHTER_POST_TAG);
 		highlighter = new Highlighter(formatter, new QueryScorer(query));

--- a/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/AbstractGenericLuceneTest.java
+++ b/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/AbstractGenericLuceneTest.java
@@ -90,7 +90,7 @@ public abstract class AbstractGenericLuceneTest {
 
 	public static final IRI PREDICATE_3 = vf.createIRI("urn:predicate3");
 
-	private static final Logger LOG = LoggerFactory.getLogger(AbstractGenericLuceneTest.class);
+	static final Logger LOG = LoggerFactory.getLogger(AbstractGenericLuceneTest.class);
 
 	protected LuceneSail sail;
 

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
 		<logback.version>1.1.2</logback.version>
 		<spring.version>4.2.1.RELEASE</spring.version>
 		<httpclient.version>4.5.2</httpclient.version>
-		<httpcore.version>4.4.4</httpcore.version>
+		<httpcore.version>4.4.5</httpcore.version>
 		<jackson.version>2.8.2</jackson.version>
 		<jsonldjava.version>0.8.3</jsonldjava.version>
 		<last.japicmp.compare.version>2.0</last.japicmp.compare.version>
@@ -247,7 +247,7 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.4</version>
+				<version>2.6</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-codec</groupId>
@@ -373,9 +373,9 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>com.spatial4j</groupId>
+				<groupId>org.locationtech.spatial4j</groupId>
 				<artifactId>spatial4j</artifactId>
-				<version>0.4.1</version>
+				<version>0.6</version>
 			</dependency>
 
 			<!-- Java Enterprise Edition -->
@@ -872,6 +872,10 @@
 							<rules>
 								<enforceBytecodeVersion>
 									<maxJdkVersion>1.8</maxJdkVersion>
+									<excludes>
+										<exclude>org.apache.logging.log4j:log4j-api</exclude>
+										<exclude>org.elasticsearch:elasticsearch</exclude>
+									</excludes>
 								</enforceBytecodeVersion>
 							</rules>
 							<fail>true</fail>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -14,7 +14,7 @@
 	<description>StackableSail implementation offering full-text search on literals, based on Solr.</description>
 
 	<properties>
-		<solr.version>6.6.4</solr.version>
+		<solr.version>6.6.1</solr.version>
 	</properties>
 
 	<dependencies>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -14,7 +14,7 @@
 	<description>StackableSail implementation offering full-text search on literals, based on Solr.</description>
 
 	<properties>
-		<solr.version>5.5.4</solr.version>
+		<solr.version>6.6.4</solr.version>
 	</properties>
 
 	<dependencies>

--- a/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrBulkUpdater.java
+++ b/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrBulkUpdater.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
 import org.eclipse.rdf4j.sail.lucene.BulkUpdater;

--- a/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrBulkUpdater.java
+++ b/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrBulkUpdater.java
@@ -36,7 +36,7 @@ public class SolrBulkUpdater implements BulkUpdater {
 		throws IOException
 	{
 		SolrDocument document = ((SolrSearchDocument)doc).getDocument();
-		addOrUpdateList.add(ClientUtils.toSolrInputDocument(document));
+		addOrUpdateList.add(SolrUtil.toSolrInputDocument(document));
 	}
 
 	@Override

--- a/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrDocumentDistance.java
+++ b/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrDocumentDistance.java
@@ -7,15 +7,15 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.solr;
 
-import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.sail.lucene.DocumentDistance;
 import org.eclipse.rdf4j.sail.lucene.util.GeoUnits;
 
 public class SolrDocumentDistance extends SolrDocumentResult implements DocumentDistance {
 
-	private final URI units;
+	private final IRI units;
 
-	public SolrDocumentDistance(SolrSearchDocument doc, URI units) {
+	public SolrDocumentDistance(SolrSearchDocument doc, IRI units) {
 		super(doc);
 		this.units = units;
 	}

--- a/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
+++ b/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
@@ -41,18 +41,18 @@ import org.eclipse.rdf4j.sail.lucene.SearchDocument;
 import org.eclipse.rdf4j.sail.lucene.SearchFields;
 import org.eclipse.rdf4j.sail.lucene.SearchQuery;
 import org.eclipse.rdf4j.sail.lucene.util.GeoUnits;
+import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.context.SpatialContextFactory;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Rectangle;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.SpatialRelation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.Iterables;
-import com.spatial4j.core.context.SpatialContext;
-import com.spatial4j.core.context.SpatialContextFactory;
-import com.spatial4j.core.shape.Point;
-import com.spatial4j.core.shape.Rectangle;
-import com.spatial4j.core.shape.Shape;
-import com.spatial4j.core.shape.SpatialRelation;
 
 /**
  * @see LuceneSail
@@ -185,7 +185,7 @@ public class SolrIndex extends AbstractSearchIndex {
 	{
 		SolrDocument document = ((SolrSearchDocument)doc).getDocument();
 		try {
-			client.add(ClientUtils.toSolrInputDocument(document));
+			client.add(SolrUtil.toSolrInputDocument(document));
 		}
 		catch (SolrServerException e) {
 			throw new IOException(e);
@@ -597,6 +597,11 @@ public class SolrIndex extends AbstractSearchIndex {
 		@Override
 		public boolean equals(Object other) {
 			return s.equals(other);
+		}
+
+		@Override
+		public SpatialContext getContext() {
+			return s.getContext();
 		}
 	}
 

--- a/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
+++ b/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
@@ -20,13 +20,12 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.SpatialParams;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.MalformedQueryException;
 import org.eclipse.rdf4j.query.algebra.Var;
@@ -323,7 +322,7 @@ public class SolrIndex extends AbstractSearchIndex {
 	 */
 	@Override
 	@Deprecated
-	protected SearchQuery parseQuery(String query, URI propertyURI)
+	protected SearchQuery parseQuery(String query, IRI propertyURI)
 		throws MalformedQueryException
 	{
 		SolrQuery q = prepareQuery(propertyURI, new SolrQuery(query));
@@ -340,7 +339,7 @@ public class SolrIndex extends AbstractSearchIndex {
 	 *         when the parsing brakes
 	 */
 	@Override
-	protected Iterable<? extends DocumentScore> query(Resource subject, String query, URI propertyURI,
+	protected Iterable<? extends DocumentScore> query(Resource subject, String query, IRI propertyURI,
 			boolean highlight)
 		throws MalformedQueryException, IOException
 	{
@@ -418,7 +417,7 @@ public class SolrIndex extends AbstractSearchIndex {
 	}
 
 	@Override
-	protected Iterable<? extends DocumentDistance> geoQuery(URI geoProperty, Point p, final URI units,
+	protected Iterable<? extends DocumentDistance> geoQuery(IRI geoProperty, Point p, final IRI units,
 			double distance, String distanceVar, Var contextVar)
 		throws MalformedQueryException, IOException
 	{
@@ -471,7 +470,7 @@ public class SolrIndex extends AbstractSearchIndex {
 	}
 
 	@Override
-	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, URI geoProperty,
+	protected Iterable<? extends DocumentResult> geoRelationQuery(String relation, IRI geoProperty,
 			Shape shape, Var contextVar)
 		throws MalformedQueryException, IOException
 	{
@@ -647,7 +646,7 @@ public class SolrIndex extends AbstractSearchIndex {
 		return client.query(query.setRows(nDocs));
 	}
 
-	private SolrQuery prepareQuery(URI propertyURI, SolrQuery query) {
+	private SolrQuery prepareQuery(IRI propertyURI, SolrQuery query) {
 		// check out which query parser to use, based on the given property URI
 		if (propertyURI == null)
 			// if we have no property given, we create a default query parser which

--- a/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrSearchQuery.java
+++ b/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrSearchQuery.java
@@ -16,8 +16,8 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.URI;
 import org.eclipse.rdf4j.sail.lucene.DocumentScore;
 import org.eclipse.rdf4j.sail.lucene.SearchFields;
 import org.eclipse.rdf4j.sail.lucene.SearchQuery;
@@ -81,7 +81,7 @@ public class SolrSearchQuery implements SearchQuery {
 	 * Highlights the given field or all fields if null.
 	 */
 	@Override
-	public void highlight(URI property) {
+	public void highlight(IRI property) {
 		query.setHighlight(true);
 		String field = (property != null) ? SearchFields.getPropertyField(property) : "*";
 		query.addHighlightField(field);

--- a/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrUtil.java
+++ b/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrUtil.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors, Aduna, and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.solr;
+
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrInputDocument;
+
+/**
+ * Utility for Solr handling
+ */
+public class SolrUtil {
+
+	/**
+	 * Converts a {@link SolrDocument} to a {@link SolrInputDocument}
+	 * 
+	 * @param solrDocument
+	 * @return
+	 */
+	public static SolrInputDocument toSolrInputDocument(SolrDocument solrDocument) {
+
+		/*
+		 * Note: ClientUtils.toSolrInputDocument was removed in solr 6 Replacement found on
+		 * https://stackoverflow.com/questions/38266684/
+		 * substitute-of-org-apache-solr-client-solrj-util-clientutils-tosolrinputdocument
+		 */
+
+		SolrInputDocument solrInputDocument = new SolrInputDocument();
+
+		for (String name : solrDocument.getFieldNames()) {
+			solrInputDocument.addField(name, solrDocument.getFieldValue(name));
+		}
+
+		//Don't forget children documents
+		if (solrDocument.getChildDocuments() != null) {
+			for (SolrDocument childDocument : solrDocument.getChildDocuments()) {
+				//You can add paranoic check against infinite loop childDocument == solrDocument
+				solrInputDocument.addChildDocument(toSolrInputDocument(childDocument));
+			}
+		}
+		return solrInputDocument;
+	}
+}

--- a/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/http/Factory.java
+++ b/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/http/Factory.java
@@ -15,6 +15,6 @@ public class Factory implements SolrClientFactory {
 
 	@Override
 	public SolrClient create(String spec) {
-		return new HttpSolrClient(spec);
+		return new HttpSolrClient.Builder(spec).build();
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: #71  .

This change updates outdated and no longer maintained versions of Lucene
and the modules using it.

Updates

Lucene: 5.5.4 -> 6.6.1
Solr: 5.5.4 -> 6.6.1
Elasticsearch: 2.4.6 -> 5.6.9


Requires updated of the following transitive dependencies

- spatial4j: 0.5 -> 0.6

