### PR TITLE
#75: Update jackson to 2.9.5, http client and http core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,9 +219,9 @@
 		<slf4j.version>1.7.10</slf4j.version>
 		<logback.version>1.1.2</logback.version>
 		<spring.version>4.2.1.RELEASE</spring.version>
-		<httpclient.version>4.5.2</httpclient.version>
-		<httpcore.version>4.4.5</httpcore.version>
-		<jackson.version>2.8.2</jackson.version>
+		<httpclient.version>4.5.5</httpclient.version>
+		<httpcore.version>4.4.9</httpcore.version>
+		<jackson.version>2.9.5</jackson.version>
 		<last.japicmp.compare.version>2.0</last.japicmp.compare.version>
 	</properties>
 


### PR DESCRIPTION
This PR addresses GitHub issue: #75 .

The following dependencies are updated

jackson: 2.8.8 -> 2.9.5
http client: 4.5.2 -> 4.5.5
http core: 4.4.4 -> 4.4.9
