### PR TITLE
Upgrade jackson to 2.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
 		<spring.version>4.2.1.RELEASE</spring.version>
 		<httpclient.version>4.5.5</httpclient.version>
 		<httpcore.version>4.4.9</httpcore.version>
-		<jackson.version>2.9.5</jackson.version>
+		<jackson.version>2.9.6</jackson.version>
 		<last.japicmp.compare.version>2.0</last.japicmp.compare.version>
 	</properties>
 


### PR DESCRIPTION
This PR addresses GitHub issue: 75# .

Updates jackson to 2.9.6 to address a security vulnerability in jackson 2.9.5

See also https://github.com/eclipse/rdf4j/issues/1035
