### PR TITLE
Fix GH-81 set project-wide version of commons-math3 to 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -247,6 +248,11 @@
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
 				<version>2.6</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-math3</artifactId>
+				<version>3.5</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-codec</groupId>
@@ -749,17 +755,17 @@
 					<version>2.1.1</version>
 					<configuration>
 						<failOnMissingWebXml>false</failOnMissingWebXml>
-                                                <archive>
-                                                        <manifestEntries>
+						<archive>
+							<manifestEntries>
 								<Implementation-Title>${project.name}</Implementation-Title>
 								<Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
 								<Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
 								<Implementation-Version>${project.version}+${buildNumber}</Implementation-Version>
 								<Implementation-Build>${buildNumber}</Implementation-Build>
-                                                        </manifestEntries>
-                                                </archive>
-                                        </configuration>
-                                </plugin>
+							</manifestEntries>
+						</archive>
+					</configuration>
+				</plugin>
 				<plugin>
 					<groupId>org.apache.tomcat.maven</groupId>
 					<artifactId>tomcat7-maven-plugin</artifactId>


### PR DESCRIPTION
This PR addresses GitHub issue: #81 .

Briefly describe the changes proposed in this PR:

* version bump of commons-math3 library to a previously-approved version, to avoid having to do full due diligence again on an older version (this is a transitive dependency of solr)
* made version setting project-wide to ensure consistency.

