### PR TITLE
Issues/rdf4j#1030 use assertj

### DIFF
--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -39,8 +39,8 @@
 			<type>test-jar</type>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -39,8 +39,9 @@
 			<type>test-jar</type>
 		</dependency>
 		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/compliance/store/pom.xml
+++ b/compliance/store/pom.xml
@@ -61,6 +61,11 @@
 			<artifactId>junit</artifactId>
 			<scope>compile</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/sail/helpers/NotifyingSailConnectionWrapperTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/sail/helpers/NotifyingSailConnectionWrapperTest.java
@@ -7,9 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.helpers;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -24,7 +22,7 @@ import org.junit.Test;
 
 /**
  * Some general tests for {@link NogifyingSailConnectionWrapper} expected behaviour.
- * 
+ *
  * @author Dale Visser
  */
 public class NotifyingSailConnectionWrapperTest {
@@ -89,7 +87,7 @@ public class NotifyingSailConnectionWrapperTest {
 
 	/**
 	 * Regression test for SES-1934.
-	 * 
+	 *
 	 * @throws SailException
 	 */
 	@Test
@@ -98,12 +96,12 @@ public class NotifyingSailConnectionWrapperTest {
 	{
 		wrapper.addConnectionListener(listener);
 		addStatement("a");
-		assertThat(listener.getCount(), is(equalTo(1)));
+		assertThat(listener.getCount()).isEqualTo(1);
 		removeStatement("a");
-		assertThat(listener.getCount(), is(equalTo(0)));
+		assertThat(listener.getCount()).isEqualTo(0);
 		wrapper.removeConnectionListener(listener);
 		addStatement("b");
-		assertThat(listener.getCount(), is(equalTo(0)));
+		assertThat(listener.getCount()).isEqualTo(0);
 	}
 
 	private void removeStatement(String objectValue)

--- a/federation/pom.xml
+++ b/federation/pom.xml
@@ -64,6 +64,11 @@ The Federation SAIL allows multiple datasets to be virtually combined into a sin
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>

--- a/federation/src/test/java/org/eclipse/rdf4j/runtime/TestRepositoryManagerFederator.java
+++ b/federation/src/test/java/org/eclipse/rdf4j/runtime/TestRepositoryManagerFederator.java
@@ -7,9 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.runtime;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,9 +20,7 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
 import org.eclipse.rdf4j.repository.manager.RepositoryManager;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /**
  * @author Dale Visser
@@ -32,9 +28,6 @@ import org.junit.rules.ExpectedException;
 public class TestRepositoryManagerFederator {
 
 	RepositoryManagerFederator federator;
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	/**
 	 * @throws java.lang.Exception
@@ -54,10 +47,10 @@ public class TestRepositoryManagerFederator {
 	public final void testDirectRecursiveAddThrowsException()
 		throws MalformedURLException, RDF4JException
 	{
-		thrown.expect(is(instanceOf(RepositoryConfigException.class)));
-		thrown.expectMessage(is(equalTo("A federation member may not have the same ID as the federation.")));
-		String id = "fedtest";
-		federator.addFed(id, "Federation Test", Arrays.asList(new String[] { id, "ignore" }), true, false);
+        String id = "fedtest";
+        assertThatThrownBy(() -> federator.addFed(id, "Federation Test", Arrays.asList(new String[] { id, "ignore" }),
+                true, false)).isInstanceOf(RepositoryConfigException.class)
+                        .hasMessage("A federation member may not have the same ID as the federation.");
 	}
 
 }

--- a/federation/src/test/java/org/eclipse/rdf4j/sail/federation/BloomFilterFederationQueryTest.java
+++ b/federation/src/test/java/org/eclipse/rdf4j/sail/federation/BloomFilterFederationQueryTest.java
@@ -7,8 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.federation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +28,7 @@ public class BloomFilterFederationQueryTest extends FederationQueryTest {
 	{
 		super.configure(federation);
 		List<Repository> members = federation.getMembers();
-		assertThat(members.size(), is(3));
+		assertThat(members).hasSize(3);
 		RepositoryBloomFilter bf1 = AccurateRepositoryBloomFilter.INCLUDE_INFERRED_INSTANCE;
 		RepositoryBloomFilter bf2 = new InaccurateRepositoryBloomFilter();
 		RepositoryBloomFilter bf3 = AccurateRepositoryBloomFilter.INCLUDE_INFERRED_INSTANCE;
@@ -37,8 +36,8 @@ public class BloomFilterFederationQueryTest extends FederationQueryTest {
 		federation.setBloomFilter(members.get(1), bf2);
 		federation.setBloomFilter(members.get(2), bf3);
 		Map<Repository, RepositoryBloomFilter> filters = federation.getBloomFilters();
-		assertThat(filters.get(members.get(0)), is(bf1));
-		assertThat(filters.get(members.get(1)), is(bf2));
-		assertThat(filters.get(members.get(2)), is(bf3));
+		assertThat(filters.get(members.get(0))).isEqualTo(bf1);
+		assertThat(filters.get(members.get(1))).isEqualTo(bf2);
+		assertThat(filters.get(members.get(2))).isEqualTo(bf3);
 	}
 }

--- a/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationNamespacesTest.java
+++ b/federation/src/test/java/org/eclipse/rdf4j/sail/federation/FederationNamespacesTest.java
@@ -7,12 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.federation;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsNot.not;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -48,9 +43,9 @@ public class FederationNamespacesTest {
 	{
 		RepositoryConnection con = createFederationWithMemberNamespaces("a", "a");
 		try {
-			assertThat(con.getNamespace(PREFIX), is(equalTo(EXPECTED_NAME)));
+			assertThat(con.getNamespace(PREFIX)).isEqualTo(EXPECTED_NAME);
 			List<Namespace> asList = Iterations.asList(con.getNamespaces());
-			assertThat(asList, hasItem(EXPECTED_NAMESPACE));
+			assertThat(asList).contains(EXPECTED_NAMESPACE);
 		}
 		finally {
 			con.close();
@@ -63,9 +58,9 @@ public class FederationNamespacesTest {
 	{
 		RepositoryConnection con = createFederationWithMemberNamespaces("a", "a", "a");
 		try {
-			assertThat(con.getNamespace(PREFIX), is(equalTo(EXPECTED_NAME)));
+			assertThat(con.getNamespace(PREFIX)).isEqualTo(EXPECTED_NAME);
 			List<Namespace> asList = Iterations.asList(con.getNamespaces());
-			assertThat(asList, hasItem(EXPECTED_NAMESPACE));
+			assertThat(asList).contains(EXPECTED_NAMESPACE);
 		}
 		finally {
 			con.close();
@@ -78,9 +73,9 @@ public class FederationNamespacesTest {
 	{
 		RepositoryConnection con = createFederationWithMemberNamespaces("a", "b");
 		try {
-			assertThat(con.getNamespace(PREFIX), is(nullValue()));
+			assertThat(con.getNamespace(PREFIX)).isNull();;
 			List<Namespace> asList = Iterations.asList(con.getNamespaces());
-			assertThat(asList, not(hasItem(EXPECTED_NAMESPACE)));
+			assertThat(asList).doesNotContain(EXPECTED_NAMESPACE);
 		}
 		finally {
 			con.close();
@@ -93,9 +88,9 @@ public class FederationNamespacesTest {
 	{
 		RepositoryConnection con = createFederationWithMemberNamespaces("a", "b", "c");
 		try {
-			assertThat(con.getNamespace(PREFIX), is(nullValue()));
+			assertThat(con.getNamespace(PREFIX)).isNull();
 			List<Namespace> asList = Iterations.asList(con.getNamespaces());
-			assertThat(asList, not(hasItem(EXPECTED_NAMESPACE)));
+			assertThat(asList).doesNotContain(EXPECTED_NAMESPACE);
 		}
 		finally {
 			con.close();

--- a/lucene-spin/pom.xml
+++ b/lucene-spin/pom.xml
@@ -32,6 +32,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>rdf4j-sail-memory</artifactId>
             <version>${project.version}</version>

--- a/lucene-spin/src/test/java/org/eclipse/rdf4j/lucene/spin/LuceneSailTupleFunctionTest.java
+++ b/lucene-spin/src/test/java/org/eclipse/rdf4j/lucene/spin/LuceneSailTupleFunctionTest.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.lucene.spin;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.MATCHES;
 import static org.eclipse.rdf4j.sail.lucene.LuceneSailSchema.QUERY;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URL;
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This brings all tests for new property function -based implementation of lucene search request.
- * 
+ *
  * @see <a href="https://github.com/eclipse/rdf4j/issues/739">issue #739</a>
  */
 public class LuceneSailTupleFunctionTest {
@@ -186,12 +186,12 @@ public class LuceneSailTupleFunctionTest {
 	 * select ?pred ?score ?label where {
 	 *    ?pred search:matches[
 	 *       search:query "ornare";
-	 *       search:score ?score 
+	 *       search:score ?score
 	 *       ] .
 	 *    ?pred rdfs:label ?label .
 	 * }
 	 * </code>
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -233,16 +233,16 @@ public class LuceneSailTupleFunctionTest {
 
 	/**
 	 * #220 exmaple was reproduced with query: <code>
-	 * select ?pred ?score ?query ?label where { 
-	 *   bind(str("ornare") as ?query) . 
-	 *   ?pred search:matches [ 
-	 *        search:query ?query; 
-	 *        search:score ?score 
-	 *        ] . 
-	 *   ?pred rdfs:label ?label . 
+	 * select ?pred ?score ?query ?label where {
+	 *   bind(str("ornare") as ?query) .
+	 *   ?pred search:matches [
+	 *        search:query ?query;
+	 *        search:score ?score
+	 *        ] .
+	 *   ?pred rdfs:label ?label .
 	 * }
 	 * </code>
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -290,12 +290,12 @@ public class LuceneSailTupleFunctionTest {
 	 * } where {
 	 *    ?pred search:matches[
 	 *       search:query "ornare";
-	 *       search:score ?score 
+	 *       search:score ?score
 	 *       ] .
 	 *    ?pred rdfs:label ?label .
 	 * }
 	 * </code>
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -362,7 +362,7 @@ public class LuceneSailTupleFunctionTest {
 			printTupleResult(query);
 			try (TupleQueryResult result = query.evaluate()) {
 				int count = countTupleResults(result);
-				Assert.assertThat(count, is(2));
+				assertThat(count).isEqualTo(2);
 			}
 		}
 		catch (Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -549,9 +549,9 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.hamcrest</groupId>
-				<artifactId>hamcrest-library</artifactId>
-				<version>1.3</version>
+				<groupId>org.assertj</groupId>
+				<artifactId>assertj-core</artifactId>
+				<version>3.10.0</version>
 				<scope>test</scope>
 			</dependency>
 

--- a/repository-sail/pom.xml
+++ b/repository-sail/pom.xml
@@ -82,6 +82,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>

--- a/repository-sail/src/test/java/org/eclipse/rdf4j/repository/sail/TestProxyRepository.java
+++ b/repository-sail/src/test/java/org/eclipse/rdf4j/repository/sail/TestProxyRepository.java
@@ -7,10 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -66,14 +63,14 @@ public class TestProxyRepository {
 	public final void testProperInitialization()
 		throws RepositoryException
 	{
-		assertThat(repository.getDataDir(), is(dataDir.getRoot()));
-		assertThat(repository.getProxiedIdentity(), is("test"));
-		assertThat(repository.isInitialized(), is(false));
-		assertThat(repository.isWritable(), is(proxied.isWritable()));
+		assertThat(repository.getDataDir()).isEqualTo(dataDir.getRoot());
+		assertThat(repository.getProxiedIdentity()).isEqualTo("test");
+		assertThat(repository.isInitialized()).isFalse();
+		assertThat(repository.isWritable()).isEqualTo(proxied.isWritable());
 		repository.initialize();
 		RepositoryConnection connection = repository.getConnection();
 		try {
-			assertThat(connection, instanceOf(SailRepositoryConnection.class));
+			assertThat(connection).isInstanceOf(SailRepositoryConnection.class);
 		}
 		finally {
 			connection.close();
@@ -100,14 +97,14 @@ public class TestProxyRepository {
 			connection.add(Thread.currentThread().getContextClassLoader().getResourceAsStream("proxy.ttl"),
 					"http://www.test.org/proxy#", RDFFormat.TURTLE);
 			count = connection.size();
-			assertThat(count, not(0L));
+			assertThat(count).isNotEqualTo(0L);
 		}
 		finally {
 			connection.close();
 		}
 		connection = repository.getConnection();
 		try {
-			assertThat(connection.size(), is(count));
+			assertThat(connection.size()).isEqualTo(count);
 		}
 		finally {
 			connection.close();

--- a/repository-sail/src/test/java/org/eclipse/rdf4j/repository/sail/config/TestProxyRepositoryFactory.java
+++ b/repository-sail/src/test/java/org/eclipse/rdf4j/repository/sail/config/TestProxyRepositoryFactory.java
@@ -7,9 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.repository.sail.config;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -33,7 +31,7 @@ public class TestProxyRepositoryFactory {
 
 	@Test
 	public final void testGetRepositoryType() {
-		assertThat(factory.getRepositoryType(), is("openrdf:ProxyRepository"));
+		assertThat(factory.getRepositoryType()).isEqualTo("openrdf:ProxyRepository");
 	}
 
 	@Test(expected = RepositoryConfigException.class)
@@ -41,7 +39,7 @@ public class TestProxyRepositoryFactory {
 		throws RepositoryConfigException
 	{
 		RepositoryImplConfig factoryConfig = factory.getConfig();
-		assertThat(factoryConfig, instanceOf(ProxyRepositoryConfig.class));
+		assertThat(factoryConfig).isInstanceOf(ProxyRepositoryConfig.class);
 		factoryConfig.validate();
 	}
 
@@ -54,12 +52,12 @@ public class TestProxyRepositoryFactory {
 		RepositoryConfig config = RepositoryConfig.create(graph,
 				GraphUtil.getUniqueSubject(graph, RDF.TYPE, RepositoryConfigSchema.REPOSITORY));
 		config.validate();
-		assertThat(config.getID(), is("proxy"));
-		assertThat(config.getTitle(), is("Test Proxy for 'memory'"));
+		assertThat(config.getID()).isEqualTo("proxy");
+		assertThat(config.getTitle()).isEqualTo("Test Proxy for 'memory'");
 		RepositoryImplConfig implConfig = config.getRepositoryImplConfig();
-		assertThat(implConfig.getType(), is("openrdf:ProxyRepository"));
-		assertThat(implConfig, instanceOf(ProxyRepositoryConfig.class));
-		assertThat(((ProxyRepositoryConfig)implConfig).getProxiedRepositoryID(), is("memory"));
+		assertThat(implConfig.getType()).isEqualTo("openrdf:ProxyRepository");
+		assertThat(implConfig).isInstanceOf(ProxyRepositoryConfig.class);
+		assertThat(((ProxyRepositoryConfig)implConfig).getProxiedRepositoryID()).isEqualTo("memory");
 
 		// Factory just needs a resolver instance to proceed with construction.
 		// It doesn't actually invoke the resolver until the repository is
@@ -67,6 +65,6 @@ public class TestProxyRepositoryFactory {
 		// getRepository(), and will have called this setter itself.
 		ProxyRepository repository = (ProxyRepository)factory.getRepository(implConfig);
 		repository.setRepositoryResolver(mock(RepositoryResolver.class));
-		assertThat(repository, instanceOf(ProxyRepository.class));
+		assertThat(repository).isInstanceOf(ProxyRepository.class);
 	}
 }

--- a/sail-spin/pom.xml
+++ b/sail-spin/pom.xml
@@ -42,6 +42,11 @@ The SPIN SAIL adds constraint checking and inferencing using SPIN to a base SAIL
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-sail-memory</artifactId>

--- a/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/EvaluationModeTest.java
+++ b/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/EvaluationModeTest.java
@@ -7,9 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.spin;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -63,8 +61,8 @@ public class EvaluationModeTest {
 				results.add(bs.getValue("s").stringValue());
 			}
 		}
-		assertThat(results.size(), is(2));
-		assertThat(results, hasItems("ex:Subj1", "ex:Subj3"));
+		assertThat(results).hasSize(2);
+		assertThat(results).contains("ex:Subj1", "ex:Subj3");
 		conn.close();
 		repo.shutDown();
 	}

--- a/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
+++ b/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
@@ -10,10 +10,9 @@
 package org.eclipse.rdf4j.sail.spin;
 
 import com.google.common.collect.Lists;
-import static org.hamcrest.CoreMatchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -214,7 +213,7 @@ public class SpifSailTest {
 		TupleQueryResult tqr = tq.evaluate();
 		for (int i = 1; i <= 3; i++) {
 			BindingSet bs = tqr.next();
-			assertThat(((Literal)bs.getValue("x")).intValue(), is(i));
+			assertThat(((Literal)bs.getValue("x")).intValue()).isEqualTo(i);
 		}
 		assertFalse(tqr.hasNext());
 	}
@@ -228,7 +227,7 @@ public class SpifSailTest {
 		TupleQueryResult tqr = tq.evaluate();
 		for (int i = 1; i <= 4; i++) {
 			BindingSet bs = tqr.next();
-			assertThat(((Literal)bs.getValue("x")).intValue(), is(i));
+			assertThat(((Literal)bs.getValue("x")).intValue()).isEqualTo(i);
 		}
 		assertFalse(tqr.hasNext());
 	}
@@ -242,7 +241,7 @@ public class SpifSailTest {
 		TupleQueryResult tqr = tq.evaluate();
 		for (int i = 1; i <= 3; i++) {
 			BindingSet bs = tqr.next();
-			assertThat(((Literal)bs.getValue("x")).stringValue(), is(Integer.toString(i)));
+			assertThat(((Literal)bs.getValue("x")).stringValue()).isEqualTo(Integer.toString(i));
 		}
 		assertFalse(tqr.hasNext());
 	}

--- a/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpinSailTest.java
+++ b/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpinSailTest.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.spin;
 
-import static org.hamcrest.CoreMatchers.isA;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -32,16 +32,11 @@ import org.eclipse.rdf4j.sail.inferencer.fc.ForwardChainingRDFSInferencer;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class SpinSailTest {
 
 	private static final String BASE_DIR = "/testcases/";
-
-	@Rule
-	public ExpectedException constraintException = ExpectedException.none();
 
 	private Repository repo;
 
@@ -76,18 +71,16 @@ public class SpinSailTest {
 	public void testAskConstraint()
 		throws Exception
 	{
-		constraintException.expectCause(isA(ConstraintViolationException.class));
-		constraintException.expectMessage("Test constraint");
-		loadStatements("testAskConstraint.ttl");
+        assertThatThrownBy(() -> loadStatements("testAskConstraint.ttl"))
+                .hasCauseInstanceOf(ConstraintViolationException.class).hasMessageContaining("Test constraint");
 	}
 
 	@Test
 	public void testTemplateConstraint()
 		throws Exception
 	{
-		constraintException.expectCause(isA(ConstraintViolationException.class));
-		constraintException.expectMessage("Invalid number of values: 0");
-		loadStatements("testTemplateConstraint.ttl");
+        assertThatThrownBy(() -> loadStatements("testTemplateConstraint.ttl"))
+                .hasCauseInstanceOf(ConstraintViolationException.class).hasMessageContaining("Invalid number of values: 0");
 	}
 
 	@Test

--- a/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpinSailWithoutRDFSInferencerTest.java
+++ b/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpinSailWithoutRDFSInferencerTest.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.spin;
 
-import static org.hamcrest.CoreMatchers.isA;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -30,16 +30,11 @@ import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class SpinSailWithoutRDFSInferencerTest {
 
 	private static final String BASE_DIR = "/testcases/";
-
-	@Rule
-	public ExpectedException constraintException = ExpectedException.none();
 
 	private Repository repo;
 
@@ -72,18 +67,16 @@ public class SpinSailWithoutRDFSInferencerTest {
 	public void testAskConstraint()
 		throws Exception
 	{
-		constraintException.expectCause(isA(ConstraintViolationException.class));
-		constraintException.expectMessage("Test constraint");
-		loadStatements("testAskConstraint.ttl");
+        assertThatThrownBy(() -> loadStatements("testAskConstraint.ttl"))
+                .hasCauseInstanceOf(ConstraintViolationException.class).hasMessageContaining("Test constraint");
 	}
 
 	@Test
 	public void testTemplateConstraint()
 		throws Exception
 	{
-		constraintException.expectCause(isA(ConstraintViolationException.class));
-		constraintException.expectMessage("Invalid number of values: 0");
-		loadStatements("testTemplateConstraint-full.ttl");
+        assertThatThrownBy(() -> loadStatements("testTemplateConstraint-full.ttl"))
+                .hasCauseInstanceOf(ConstraintViolationException.class).hasMessageContaining("Invalid number of values: 0");
 	}
 
 	@Test


### PR DESCRIPTION
This PR addresses GitHub issue eclipse/rdf4j#1030.

* Switch over to AssertJ for assertions
* Use `assertThatThrownBy` instead of the `ExpectedException` rule

