### PR TITLE
eclipse/rdf4j#1047 commons-io 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.5</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1047 .

Briefly describe the changes proposed in this PR:

* bumpd commons-io to 2.5 to preserve compatibility with solr 6.6 

