### PR TITLE
GH-87 add geosparql tests for Lucene

### DIFF
--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialSupport.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialSupport.java
@@ -14,14 +14,14 @@ import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.context.SpatialContextFactory;
 
 /**
- * This class is responsible for creating the {@link com.spatial4j.core.context.SpatialContext},
- * {@link SpatialAlegbra} and {@link WktWriter} that will be used. It will first try to load a subclass of
+ * This class is responsible for creating the {@link org.locationtech.spatial4j.context.SpatialContext},
+ * {@link SpatialAlgebra} and {@link WktWriter} that will be used. It will first try to load a subclass of
  * itself called "org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql.SpatialSupportInitializer" .
  * This is not provided, and is primarily intended as a way to inject JTS support. If this fails then the
  * following fall-backs are used:
  * <ul>
  * <li>a SpatialContext created by passing system properties with the prefix "spatialSupport." to
- * {@link com.spatial4j.core.context.SpatialContextFactory} . The prefix is stripped from the system property
+ * {@link org.locationtech.spatial4j.context.SpatialContextFactory} . The prefix is stripped from the system property
  * name to form the SpatialContextFactory argument name.</li>
  * <li>a SpatialAlgebra that does not support any operation.</li>
  * <li>a WktWriter that only supports points</li>.

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecBuilder.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecBuilder.java
@@ -64,9 +64,6 @@ public class DistanceQuerySpecBuilder implements SearchQueryInterpreter {
 					ValueExpr dist = null;
 					String distanceVar = null;
 					QueryModelNode parent = f.getParentNode();
-					while(!(parent instanceof ExtensionElem || parent instanceof Compare)) {
-						parent = parent.getParentNode();
-					}
 					if (parent instanceof ExtensionElem) {
 						distanceVar = ((ExtensionElem)parent).getName();
 						QueryModelNode extension = parent.getParentNode();
@@ -88,12 +85,8 @@ public class DistanceQuerySpecBuilder implements SearchQueryInterpreter {
 							dist = compare.getLeftArg();
 						}
 					}
-					else {
-						throw new SailException("missing outcome variable or comparison for distance function: " + f.getSignature());
-					}
 
-					DistanceQuerySpec spec = new DistanceQuerySpec(f, dist,
-							distanceVar, filter);
+					DistanceQuerySpec spec = new DistanceQuerySpec(f, dist, distanceVar, filter);
 					specs.put(spec.getGeoVar(), spec);
 				}
 			}
@@ -112,7 +105,9 @@ public class DistanceQuerySpecBuilder implements SearchQueryInterpreter {
 							// constant optimizer
 							results.add(spec);
 						}
-						else {
+						else if (spec.getDistanceFunctionCall() != null && spec.getDistanceExpr() != null
+								&& spec.getGeoProperty() != null)
+						{
 							// evaluate later
 							TupleFunctionCall funcCall = new TupleFunctionCall();
 							funcCall.setURI(LuceneSailSchema.WITHIN_DISTANCE.toString());

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecBuilder.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecBuilder.java
@@ -64,6 +64,9 @@ public class DistanceQuerySpecBuilder implements SearchQueryInterpreter {
 					ValueExpr dist = null;
 					String distanceVar = null;
 					QueryModelNode parent = f.getParentNode();
+					while(!(parent instanceof ExtensionElem || parent instanceof Compare)) {
+						parent = parent.getParentNode();
+					}
 					if (parent instanceof ExtensionElem) {
 						distanceVar = ((ExtensionElem)parent).getName();
 						QueryModelNode extension = parent.getParentNode();
@@ -84,6 +87,9 @@ public class DistanceQuerySpecBuilder implements SearchQueryInterpreter {
 						else if (op == CompareOp.GT && compare.getRightArg() == f) {
 							dist = compare.getLeftArg();
 						}
+					}
+					else {
+						throw new SailException("missing outcome variable or comparison for distance function: " + f.getSignature());
 					}
 
 					DistanceQuerySpec spec = new DistanceQuerySpec(f, dist,

--- a/lucene/pom.xml
+++ b/lucene/pom.xml
@@ -1,5 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -68,7 +69,19 @@
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
-		
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-lucene-testsuite</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-queryalgebra-geosparql</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -86,10 +99,10 @@
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-                <dependency>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                    <scope>test</scope>
-                </dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneGeoSPARQLTest.java
+++ b/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneGeoSPARQLTest.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+	 *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailGeoSPARQLTest;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class LuceneGeoSPARQLTest extends AbstractLuceneSailGeoSPARQLTest {
+
+	private static final String DATA_DIR = "target/test-data";
+
+	@Override
+	protected void configure(LuceneSail sail) {
+		sail.setParameter(LuceneSail.LUCENE_RAMDIR_KEY, "true");
+	}
+
+	@Override
+	protected void loadPolygons() {
+		// do nothing - JTS is required
+	}
+
+	@Override
+	protected void checkPolygons() {
+		// do nothing - JTS is required
+	}
+
+	@Test
+	@Ignore // JTS is required
+	@Override
+	public void testIntersectionQuery()
+		throws RepositoryException,
+		MalformedQueryException,
+		QueryEvaluationException
+	{
+		super.testIntersectionQuery();
+	}
+
+	@Test
+	@Ignore // JTS is required
+	@Override
+	public void testComplexIntersectionQuery()
+		throws RepositoryException,
+		MalformedQueryException,
+		QueryEvaluationException
+	{
+		super.testComplexIntersectionQuery();
+	}
+
+	@Override
+	public void tearDown()
+		throws IOException,
+		RepositoryException
+	{
+		super.tearDown();
+		FileUtils.deleteDirectory(new File(DATA_DIR));
+	}
+}


### PR DESCRIPTION
This PR addresses GitHub issue: #87 .

Briefly describe the changes proposed in this PR:

* iterate upwards over parents until the correct kind of query model node is found
* fail with a SailException if no correct node can be found
* added the GeoSPARQL testsuite for Lucene. See related PR https://github.com/eclipse/rdf4j-testsuite/pull/29 for a proposed additional test that covers this issue (unmerged because it fails with other errors).
