### PR TITLE
#104 renamed Shape to NodeShape

### DIFF
--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
@@ -37,8 +37,8 @@ public class DatatypePropertyShape extends PathPropertyShape {
 
 	private final Resource datatype;
 
-	DatatypePropertyShape(Resource id, SailRepositoryConnection connection, Shape shape) {
-		super(id, connection, shape);
+	DatatypePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+		super(id, connection, nodeShape);
 
 		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.DATATYPE, null, true))) {
 			datatype = stream.map(Statement::getObject).map(v -> (Resource) v).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:datatype on " + id));
@@ -48,9 +48,9 @@ public class DatatypePropertyShape extends PathPropertyShape {
 
 
 	@Override
-	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 
-		PlanNode addedByShape = new LoggingNode(shape.getPlanAddedStatements(shaclSailConnection, shape));
+		PlanNode addedByShape = new LoggingNode(nodeShape.getPlanAddedStatements(shaclSailConnection, nodeShape));
 
 		BufferedSplitter bufferedSplitter = new BufferedSplitter(addedByShape);
 
@@ -66,8 +66,8 @@ public class DatatypePropertyShape extends PathPropertyShape {
 		PlanNode top = new LoggingNode(new InnerJoin(bufferedSplitter.getPlanNode(), invalidValuesDirectOnPath, null, discardedRight));
 
 
-		if (shape instanceof TargetClass) {
-			PlanNode typeFilterPlan = new LoggingNode(((TargetClass) shape).getTypeFilterPlan(shaclSailConnection.getPreviousStateConnection(), discardedRight));
+		if (nodeShape instanceof TargetClass) {
+			PlanNode typeFilterPlan = new LoggingNode(((TargetClass) nodeShape).getTypeFilterPlan(shaclSailConnection.getPreviousStateConnection(), discardedRight));
 
 			top = new LoggingNode(new UnionNode(top, typeFilterPlan));
 		}
@@ -85,10 +85,10 @@ public class DatatypePropertyShape extends PathPropertyShape {
 			System.out.println("labelloc=t;\nfontsize=30;\nlabel=\""+this.getClass().getSimpleName()+"\";");
 
 			invalidValues.printPlan();
-			System.out.println(System.identityHashCode(shaclSailConnection) + " [label=\"" + StringEscapeUtils.escapeJava("Base sail") + "\" shape=pentagon fillcolor=lightblue style=filled];");
-			System.out.println(System.identityHashCode(shaclSailConnection.getAddedStatements()) + " [label=\"" + StringEscapeUtils.escapeJava("Added statements") + "\" shape=pentagon fillcolor=lightblue style=filled];");
-			System.out.println(System.identityHashCode(shaclSailConnection.getRemovedStatements()) + " [label=\"" + StringEscapeUtils.escapeJava("Removed statements") + "\" shape=pentagon fillcolor=lightblue style=filled];");
-			System.out.println(System.identityHashCode(shaclSailConnection.getPreviousStateConnection()) + " [label=\"" + StringEscapeUtils.escapeJava("Previous state connection") + "\" shape=pentagon fillcolor=lightblue style=filled];");
+			System.out.println(System.identityHashCode(shaclSailConnection) + " [label=\"" + StringEscapeUtils.escapeJava("Base sail") + "\" nodeShape=pentagon fillcolor=lightblue style=filled];");
+			System.out.println(System.identityHashCode(shaclSailConnection.getAddedStatements()) + " [label=\"" + StringEscapeUtils.escapeJava("Added statements") + "\" nodeShape=pentagon fillcolor=lightblue style=filled];");
+			System.out.println(System.identityHashCode(shaclSailConnection.getRemovedStatements()) + " [label=\"" + StringEscapeUtils.escapeJava("Removed statements") + "\" nodeShape=pentagon fillcolor=lightblue style=filled];");
+			System.out.println(System.identityHashCode(shaclSailConnection.getPreviousStateConnection()) + " [label=\"" + StringEscapeUtils.escapeJava("Previous state connection") + "\" nodeShape=pentagon fillcolor=lightblue style=filled];");
 
 			System.out.println("}");
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
@@ -33,7 +33,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 import java.util.stream.Stream;
 
 /**
- * The AST (Abstract Syntax Tree) node that represents a sh:maxCount property shape restriction.
+ * The AST (Abstract Syntax Tree) node that represents a sh:maxCount property nodeShape restriction.
  *
  * @author Håvard Ottestad
  */
@@ -41,8 +41,8 @@ public class MaxCountPropertyShape extends PathPropertyShape {
 
 	private long maxCount;
 
-	MaxCountPropertyShape(Resource id, SailRepositoryConnection connection, Shape shape) {
-		super(id, connection, shape);
+	MaxCountPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+		super(id, connection, nodeShape);
 
 		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.MAX_COUNT, null, true))) {
 			maxCount = stream.map(Statement::getObject).map(v -> (Literal) v).map(Literal::longValue).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:maxCount on " + id));
@@ -55,15 +55,15 @@ public class MaxCountPropertyShape extends PathPropertyShape {
 		return "MaxCountPropertyShape{" + "maxCount=" + maxCount + '}';
 	}
 
-	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 
 
-		PlanNode planAddedStatements = new LoggingNode(shape.getPlanAddedStatements(shaclSailConnection, shape));
+		PlanNode planAddedStatements = new LoggingNode(nodeShape.getPlanAddedStatements(shaclSailConnection, nodeShape));
 
-		PlanNode planAddedStatements1 = new LoggingNode(super.getPlanAddedStatements(shaclSailConnection, shape));
+		PlanNode planAddedStatements1 = new LoggingNode(super.getPlanAddedStatements(shaclSailConnection, nodeShape));
 
-		if (shape instanceof TargetClass) {
-			planAddedStatements1 = new LoggingNode(((TargetClass) shape).getTypeFilterPlan(shaclSailConnection, planAddedStatements1));
+		if (nodeShape instanceof TargetClass) {
+			planAddedStatements1 = new LoggingNode(((TargetClass) nodeShape).getTypeFilterPlan(shaclSailConnection, planAddedStatements1));
 		}
 
 		PlanNode mergeNode = new LoggingNode(new UnionNode(planAddedStatements, planAddedStatements1));
@@ -94,10 +94,10 @@ public class MaxCountPropertyShape extends PathPropertyShape {
 			System.out.println("labelloc=t;\nfontsize=30;\nlabel=\""+this.getClass().getSimpleName()+"\";");
 
 			mergeNode1.printPlan();
-			System.out.println(System.identityHashCode(shaclSailConnection) + " [label=\"" + StringEscapeUtils.escapeJava("Base sail") + "\" shape=pentagon fillcolor=lightblue style=filled];");
-			System.out.println(System.identityHashCode(shaclSailConnection.getAddedStatements()) + " [label=\"" + StringEscapeUtils.escapeJava("Added statements") + "\" shape=pentagon fillcolor=lightblue style=filled];");
-			System.out.println(System.identityHashCode(shaclSailConnection.getRemovedStatements()) + " [label=\"" + StringEscapeUtils.escapeJava("Removed statements") + "\" shape=pentagon fillcolor=lightblue style=filled];");
-			System.out.println(System.identityHashCode(shaclSailConnection.getPreviousStateConnection()) + " [label=\"" + StringEscapeUtils.escapeJava("Previous state connection") + "\" shape=pentagon fillcolor=lightblue style=filled];");
+			System.out.println(System.identityHashCode(shaclSailConnection) + " [label=\"" + StringEscapeUtils.escapeJava("Base sail") + "\" nodeShape=pentagon fillcolor=lightblue style=filled];");
+			System.out.println(System.identityHashCode(shaclSailConnection.getAddedStatements()) + " [label=\"" + StringEscapeUtils.escapeJava("Added statements") + "\" nodeShape=pentagon fillcolor=lightblue style=filled];");
+			System.out.println(System.identityHashCode(shaclSailConnection.getRemovedStatements()) + " [label=\"" + StringEscapeUtils.escapeJava("Removed statements") + "\" nodeShape=pentagon fillcolor=lightblue style=filled];");
+			System.out.println(System.identityHashCode(shaclSailConnection.getPreviousStateConnection()) + " [label=\"" + StringEscapeUtils.escapeJava("Previous state connection") + "\" nodeShape=pentagon fillcolor=lightblue style=filled];");
 
 			System.out.println("}");
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeShape.java
@@ -27,40 +27,40 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * The AST (Abstract Syntax Tree) node that represents the Shape node. Shape nodes can have multiple property shapes, which are the restrictions for everything that matches the Shape.
+ * The AST (Abstract Syntax Tree) node that represents the NodeShape node. NodeShape nodes can have multiple property nodeShapes, which are the restrictions for everything that matches the NodeShape.
  *
  * @author Heshan Jayasinghe
  */
-public class Shape implements PlanGenerator, RequiresEvalutation, QueryGenerator {
+public class NodeShape implements PlanGenerator, RequiresEvalutation, QueryGenerator {
 
 	private Resource id;
 
 	private List<PropertyShape> propertyShapes;
 
-	public Shape(Resource id, SailRepositoryConnection connection) {
+	public NodeShape(Resource id, SailRepositoryConnection connection) {
 		this.id = id;
 		propertyShapes = PropertyShape.Factory.getProprtyShapes(id, connection, this);
 	}
 
 	@Override
-	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		return new TrimTuple(new LoggingNode(new Select(shaclSailConnection.getAddedStatements(), getQuery())), 1);
 	}
 
 	@Override
-	public PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		return new TrimTuple(new LoggingNode(new Select(shaclSailConnection.getRemovedStatements(), getQuery())), 1);
 	}
 
-	public List<PlanNode> generatePlans(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public List<PlanNode> generatePlans(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		return propertyShapes.stream()
 			.filter(propertyShape -> propertyShape.requiresEvaluation(shaclSailConnection.getAddedStatements(), shaclSailConnection.getRemovedStatements()))
-			.map(propertyShape -> propertyShape.getPlan(shaclSailConnection, shape))
+			.map(propertyShape -> propertyShape.getPlan(shaclSailConnection, nodeShape))
 			.collect(Collectors.toList());
 	}
 
@@ -79,13 +79,13 @@ public class Shape implements PlanGenerator, RequiresEvalutation, QueryGenerator
 
 	public static class Factory {
 
-		public static List<Shape> getShapes(SailRepositoryConnection connection) {
-			try (Stream<Statement> stream = Iterations.stream(connection.getStatements(null, RDF.TYPE, SHACL.SHAPE))) {
+		public static List<NodeShape> getShapes(SailRepositoryConnection connection) {
+			try (Stream<Statement> stream = Iterations.stream(connection.getStatements(null, RDF.TYPE, SHACL.NODE_SHAPE))) {
 				return stream.map(Statement::getSubject).map(shapeId -> {
 					if (hasTargetClass(shapeId, connection)) {
 						return new TargetClass(shapeId, connection);
 					} else {
-						return new Shape(shapeId, connection); // target class shapes are the only supported shapes
+						return new NodeShape(shapeId, connection); // target class nodeShapes are the only supported nodeShapes
 					}
 				})
 					.filter(Objects::nonNull)

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PathPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PathPropertyShape.java
@@ -16,7 +16,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Select;
 
 /**
- * The AST (Abstract Syntax Tree) node that represents the sh:path on a property shape.
+ * The AST (Abstract Syntax Tree) node that represents the sh:path on a property nodeShape.
  *
  * @author Heshan Jayasinghe
  */
@@ -24,8 +24,8 @@ public class PathPropertyShape extends PropertyShape {
 
 	Path path;
 
-	PathPropertyShape(Resource id, SailRepositoryConnection connection, Shape shape) {
-		super(id, shape);
+	PathPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+		super(id, nodeShape);
 
 		// only simple path is supported. There are also no checks. Any use of paths that are not single predicates is undefined.
 		path = new SimplePath(id, connection);
@@ -33,17 +33,17 @@ public class PathPropertyShape extends PropertyShape {
 	}
 
 	@Override
-	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		return new Select(shaclSailConnection, path.getQuery());
 	}
 
 	@Override
-	public PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		return new Select(shaclSailConnection.getAddedStatements(), path.getQuery());
 	}
 
 	@Override
-	public PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		return new Select(shaclSailConnection.getRemovedStatements(), path.getQuery());
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PlanGenerator.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PlanGenerator.java
@@ -16,11 +16,11 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
  */
 public interface PlanGenerator {
 
-	PlanNode getPlan(ShaclSailConnection shaclSailConnection, Shape shape);
+	PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape);
 
-	PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, Shape shape);
+	PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape);
 
-	PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, Shape shape);
+	PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape);
 
 
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * The AST (Abstract Syntax Tree) node that represents a property shape without any restrictions. This node should be extended by other nodes.
+ * The AST (Abstract Syntax Tree) node that represents a property nodeShape without any restrictions. This node should be extended by other nodes.
  *
  * @author Heshan Jayasinghe
  */
@@ -31,26 +31,26 @@ public class PropertyShape implements PlanGenerator, RequiresEvalutation {
 
 	private Resource id;
 
-	Shape shape;
+	NodeShape nodeShape;
 
 
-	PropertyShape(Resource id, Shape shape) {
+	PropertyShape(Resource id, NodeShape nodeShape) {
 		this.id = id;
-		this.shape = shape;
+		this.nodeShape = nodeShape;
 	}
 
 	@Override
-	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		throw new IllegalStateException("Should never get here!!!");
 	}
 
 	@Override
-	public PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		throw new IllegalStateException("Should never get here!!!");
 	}
 
 	@Override
-	public PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		throw new IllegalStateException("Should never get here!!!");
 	}
 
@@ -61,7 +61,7 @@ public class PropertyShape implements PlanGenerator, RequiresEvalutation {
 
 	static class Factory {
 
-		static List<PropertyShape> getProprtyShapes(Resource ShapeId, SailRepositoryConnection connection, Shape shape) {
+		static List<PropertyShape> getProprtyShapes(Resource ShapeId, SailRepositoryConnection connection, NodeShape nodeShape) {
 
 			try (Stream<Statement> stream = Iterations.stream(connection.getStatements(ShapeId, SHACL.PROPERTY, null))) {
 				return stream
@@ -71,15 +71,15 @@ public class PropertyShape implements PlanGenerator, RequiresEvalutation {
 						List<PropertyShape> propertyShapes = new ArrayList<>(2);
 
 						if (hasMinCount(propertyShapeId, connection)) {
-							propertyShapes.add(new MinCountPropertyShape(propertyShapeId, connection, shape));
+							propertyShapes.add(new MinCountPropertyShape(propertyShapeId, connection, nodeShape));
 						}
 
 						if (hasMaxCount(propertyShapeId, connection)) {
-							propertyShapes.add(new MaxCountPropertyShape(propertyShapeId, connection, shape));
+							propertyShapes.add(new MaxCountPropertyShape(propertyShapeId, connection, nodeShape));
 						}
 
 						if (hasDatatype(propertyShapeId, connection)) {
-							propertyShapes.add(new DatatypePropertyShape(propertyShapeId, connection, shape));
+							propertyShapes.add(new DatatypePropertyShape(propertyShapeId, connection, nodeShape));
 						}
 
 						return propertyShapes.stream();

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetClass.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetClass.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
  *
  * @author Heshan Jayasinghe
  */
-public class TargetClass extends Shape {
+public class TargetClass extends NodeShape {
 
 	Resource targetClass;
 
@@ -45,18 +45,18 @@ public class TargetClass extends Shape {
 	}
 
 	@Override
-	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		return new TrimTuple(new LoggingNode(new Select(shaclSailConnection, getQuery())), 1);
 	}
 
 	@Override
-	public PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		return new TrimTuple(new LoggingNode(new Select(shaclSailConnection.getAddedStatements(), getQuery())), 1);
 
 	}
 
 	@Override
-	public PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, Shape shape) {
+	public PlanNode getPlanRemovedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape) {
 		return new Select(shaclSailConnection.getRemovedStatements(), getQuery());
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -14,7 +14,7 @@ import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.helpers.NotifyingSailWrapper;
-import org.eclipse.rdf4j.sail.shacl.AST.Shape;
+import org.eclipse.rdf4j.sail.shacl.AST.NodeShape;
 
 import java.util.List;
 
@@ -23,7 +23,7 @@ import java.util.List;
  */
 public class ShaclSail extends NotifyingSailWrapper {
 
-	public List<Shape> shapes;
+	public List<NodeShape> nodeShapes;
 	boolean debugPrintPlans = false;
 
 	ShaclSailConfig config = new ShaclSailConfig();
@@ -31,7 +31,7 @@ public class ShaclSail extends NotifyingSailWrapper {
 	public ShaclSail(NotifyingSail baseSail, SailRepository shaclSail) {
 		super(baseSail);
 		try (SailRepositoryConnection shaclSailConnection = shaclSail.getConnection()) {
-			shapes = Shape.Factory.getShapes(shaclSailConnection);
+			nodeShapes = NodeShape.Factory.getShapes(shaclSailConnection);
 		}
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.sail.SailConnectionListener;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.helpers.NotifyingSailConnectionWrapper;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.eclipse.rdf4j.sail.shacl.AST.Shape;
+import org.eclipse.rdf4j.sail.shacl.AST.NodeShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Tuple;
 import org.slf4j.Logger;
@@ -177,15 +177,15 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper {
 
 		boolean allValid = true;
 
-		for (Shape shape : sail.shapes) {
-			List<PlanNode> planNodes = shape.generatePlans(this, shape);
+		for (NodeShape nodeShape : sail.nodeShapes) {
+			List<PlanNode> planNodes = nodeShape.generatePlans(this, nodeShape);
 			for (PlanNode planNode : planNodes) {
 				try (Stream<Tuple> stream = Iterations.stream(planNode.iterator())) {
 					List<Tuple> collect = stream.collect(Collectors.toList());
 
 					boolean valid = collect.size() == 0;
 					if (!valid) {
-						logger.warn("SHACL not valid. The following experimental debug results were produced: \n\tShape: {} \n\t\t{}", shape.toString(), String.join("\n\t\t", collect.stream().map(a -> a.toString()+" -cause-> "+a.getCause()).collect(Collectors.toList())));
+						logger.warn("SHACL not valid. The following experimental debug results were produced: \n\tNodeShape: {} \n\t\t{}", nodeShape.toString(), String.join("\n\t\t", collect.stream().map(a -> a.toString()+" -cause-> "+a.getCause()).collect(Collectors.toList())));
 					}
 					allValid = allValid && valid;
 				}

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ReduceNumberOfPlansTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ReduceNumberOfPlansTest.java
@@ -40,7 +40,7 @@ public class ReduceNumberOfPlansTest {
 			ShaclSailConnection sailConnection = (ShaclSailConnection) connection.getSailConnection();
 
 			sailConnection.fillAddedAndRemovedStatementRepositories();
-			List<PlanNode> collect = sailConnection.sail.shapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
+			List<PlanNode> collect = sailConnection.sail.nodeShapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
 
 			assertEquals(0, collect.size());
 
@@ -48,7 +48,7 @@ public class ReduceNumberOfPlansTest {
 			connection.add(person1, RDF.TYPE, Utils.Ex.Person);
 			sailConnection.fillAddedAndRemovedStatementRepositories();
 
-			List<PlanNode> collect2 = sailConnection.sail.shapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
+			List<PlanNode> collect2 = sailConnection.sail.nodeShapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
 
 			assertEquals(2, collect2.size());
 			ValueFactory vf = connection.getValueFactory();
@@ -95,7 +95,7 @@ public class ReduceNumberOfPlansTest {
 
 			sailConnection.fillAddedAndRemovedStatementRepositories();
 
-			List<PlanNode> collect1 = sailConnection.sail.shapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
+			List<PlanNode> collect1 = sailConnection.sail.nodeShapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
 			assertEquals(1, collect1.size());
 
 			connection.remove(person1, Utils.Ex.ssn, vf.createLiteral("a"));
@@ -103,13 +103,13 @@ public class ReduceNumberOfPlansTest {
 
 			sailConnection.fillAddedAndRemovedStatementRepositories();
 
-			List<PlanNode> collect2 = sailConnection.sail.shapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
+			List<PlanNode> collect2 = sailConnection.sail.nodeShapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
 			assertEquals(1, collect2.size());
 
 			connection.remove(person1, Utils.Ex.name, vf.createLiteral("c"));
 			sailConnection.fillAddedAndRemovedStatementRepositories();
 
-			List<PlanNode> collect3 = sailConnection.sail.shapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
+			List<PlanNode> collect3 = sailConnection.sail.nodeShapes.stream().flatMap(shape -> shape.generatePlans(sailConnection, shape).stream()).collect(Collectors.toList());
 			assertEquals(2, collect3.size());
 
 

--- a/shacl/src/test/resources/reduceNumberOfPlansTest/shacl.ttl
+++ b/shacl/src/test/resources/reduceNumberOfPlansTest/shacl.ttl
@@ -6,7 +6,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:shape1
-	a sh:Shape ;
+	a sh:NodeShape  ;
 	sh:targetClass ex:Person ;
 	sh:property [
 		sh:path ex:ssn ;
@@ -22,7 +22,7 @@ ex:shape1
 
 
 ex:shape2
-	a sh:Shape ;
+	a sh:NodeShape  ;
 	sh:targetClass ex:OtherPerson ;
 	sh:property [
 		sh:path ex:age ;

--- a/shacl/src/test/resources/shacl.ttl
+++ b/shacl/src/test/resources/shacl.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:PersonShape
-	a sh:Shape ;
+	a sh:NodeShape  ;
 	sh:targetClass rdfs:Resource ;
 	sh:property [
 		sh:path rdfs:label ;

--- a/shacl/src/test/resources/shaclDatatype.ttl
+++ b/shacl/src/test/resources/shaclDatatype.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:PersonShape
-	a sh:Shape ;
+	a sh:NodeShape  ;
 	sh:targetClass rdfs:Resource ;
 	sh:property [
 		sh:path foaf:age ;

--- a/shacl/src/test/resources/shaclMax.ttl
+++ b/shacl/src/test/resources/shaclMax.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:PersonShape
-	a sh:Shape ;
+	a sh:NodeShape  ;
 	sh:targetClass rdfs:Resource ;
 	sh:property [
 		sh:path rdfs:label ;

--- a/shacl/src/test/resources/shacleNoTargetClass.ttl
+++ b/shacl/src/test/resources/shacleNoTargetClass.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:EverythingShape
-	a sh:Shape ;
+	a sh:NodeShape  ;
 	sh:property [
 		sh:path rdfs:label ;
 		sh:minCount 1 ;

--- a/shacl/src/test/resources/test-cases/datatype/simple/shacl.ttl
+++ b/shacl/src/test/resources/test-cases/datatype/simple/shacl.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:PersonShape
-	a sh:Shape ;
+	a sh:NodeShape  ;
 	sh:targetClass ex:Person ;
 	sh:property [
 		sh:path ex:age ;

--- a/shacl/src/test/resources/test-cases/minCount/simple/shacl.ttl
+++ b/shacl/src/test/resources/test-cases/minCount/simple/shacl.ttl
@@ -7,7 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 ex:PersonShape
-	a sh:Shape ;
+	a sh:NodeShape  ;
 	sh:targetClass ex:Person ;
 	sh:property [
 		sh:path ex:ssn ;


### PR DESCRIPTION
This PR addresses GitHub issue: #104 .

Briefly describe the changes proposed in this PR:

* renamed code from Shape to NodeShape
* filter subjects for NodeShape instead of Shape (not backwards compatible)
* update tests
