### PR TITLE
eclipse/rdf4j#1018 fix handling of null binding in iteration

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSet.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryBindingSet.java
@@ -124,7 +124,9 @@ public class QueryBindingSet extends AbstractBindingSet {
 	}
 
 	public Iterator<Binding> iterator() {
-		Iterator<Map.Entry<String, Value>> entries = bindings.entrySet().iterator();
+
+		Iterator<Map.Entry<String, Value>> entries = bindings.entrySet().stream().filter(
+				entry -> entry.getValue() != null).iterator();
 
 		return new ConvertingIterator<Map.Entry<String, Value>, Binding>(entries) {
 
@@ -148,5 +150,4 @@ public class QueryBindingSet extends AbstractBindingSet {
 			return super.equals(other);
 		}
 	}
-
 }


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1018 .

Briefly describe the changes proposed in this PR:

* QueryBindingSet iterator filters out any bindings with a `null` special value (see eclipse/rdf4j#79)
* added regression test

