### PR TITLE
Fixes geosparql errors

### DIFF
--- a/geosparql/pom.xml
+++ b/geosparql/pom.xml
@@ -43,6 +43,11 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/FunctionArguments.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/FunctionArguments.java
@@ -12,6 +12,7 @@ import java.text.ParseException;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.Literals;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
@@ -39,9 +40,18 @@ class FunctionArguments {
 	 * @return double
 	 * @throws ValueExprEvaluationException 
 	 */
-	public static double getDouble(Function func, Value v) throws ValueExprEvaluationException {
-		Literal l = getLiteral(func, v, XMLSchema.DOUBLE);
-		return l.doubleValue();
+	public static double getDouble(Function func, Value v) throws ValueExprEvaluationException { 
+		if (!(v instanceof Literal)) {
+			throw new ValueExprEvaluationException("Invalid argument for " + func.getURI() + ": " + v);
+		}
+		
+		try {
+			return ((Literal)v).doubleValue();
+		}
+		catch (NumberFormatException e) {
+			throw new ValueExprEvaluationException(e);
+		}
+		
 	}
 
 	/**

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunction.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunction.java
@@ -31,14 +31,14 @@ abstract class GeometricBinaryFunction implements Function {
 		SpatialContext geoContext = SpatialSupport.getSpatialContext();
 		Shape geom1 = FunctionArguments.getShape(this, args[0], geoContext);
 		Shape geom2 = FunctionArguments.getShape(this, args[1], geoContext);
-		Shape result = operation(geom1, geom2);
 
 		String wkt;
 		try {
+			Shape result = operation(geom1, geom2);
 			wkt = SpatialSupport.getWktWriter().toWkt(result);
 		}
-		catch (IOException ioe) {
-			throw new ValueExprEvaluationException(ioe);
+		catch (IOException|RuntimeException e) {
+			throw new ValueExprEvaluationException(e);
 		}
 		return valueFactory.createLiteral(wkt, GEO.WKT_LITERAL);
 	}

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunction.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunction.java
@@ -17,9 +17,7 @@ import org.locationtech.spatial4j.shape.Shape;
 abstract class GeometricRelationFunction implements Function {
 
 	@Override
-	public Value evaluate(ValueFactory valueFactory, Value... args)
-		throws ValueExprEvaluationException
-	{
+	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
 		if (args.length != 2) {
 			throw new ValueExprEvaluationException(
 					getURI() + " requires exactly 2 arguments, got " + args.length);
@@ -28,9 +26,14 @@ abstract class GeometricRelationFunction implements Function {
 		SpatialContext geoContext = SpatialSupport.getSpatialContext();
 		Shape geom1 = FunctionArguments.getShape(this, args[0], geoContext);
 		Shape geom2 = FunctionArguments.getShape(this, args[1], geoContext);
-		boolean result = relation(geom1, geom2);
+		try {
+			boolean result = relation(geom1, geom2);
 
-		return valueFactory.createLiteral(result);
+			return valueFactory.createLiteral(result);
+		}
+		catch (RuntimeException e) {
+			throw new ValueExprEvaluationException("error evaluating geospatial relation", e);
+		}
 	}
 
 	protected abstract boolean relation(Shape g1, Shape g2);

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunction.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunction.java
@@ -20,9 +20,7 @@ import org.locationtech.spatial4j.shape.Shape;
 abstract class GeometricUnaryFunction implements Function {
 
 	@Override
-	public Value evaluate(ValueFactory valueFactory, Value... args)
-		throws ValueExprEvaluationException
-	{
+	public Value evaluate(ValueFactory valueFactory, Value... args) throws ValueExprEvaluationException {
 		if (args.length != 1) {
 			throw new ValueExprEvaluationException(
 					getURI() + " requires exactly 1 argument, got " + args.length);
@@ -30,15 +28,15 @@ abstract class GeometricUnaryFunction implements Function {
 
 		SpatialContext geoContext = SpatialSupport.getSpatialContext();
 		Shape geom = FunctionArguments.getShape(this, args[0], geoContext);
-		Shape result = operation(geom);
 
 		String wkt;
 		try {
-			wkt = SpatialSupport.getWktWriter().toWkt(result);
+			wkt = SpatialSupport.getWktWriter().toWkt(operation(geom));
 		}
-		catch (IOException ioe) {
-			throw new ValueExprEvaluationException(ioe);
+		catch (IOException | RuntimeException e) {
+			throw new ValueExprEvaluationException(e);
 		}
+
 		return valueFactory.createLiteral(wkt, GEO.WKT_LITERAL);
 	}
 

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/BoundaryTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/BoundaryTest.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+
+public class BoundaryTest extends GeometricUnaryFunctionTest {
+
+	@Override
+	protected GeometricUnaryFunction testedFunction() {
+		return new Boundary();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/BufferTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/BufferTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.junit.Test;
+
+/**
+ * @author jeen
+ */
+public class BufferTest {
+
+	private final Buffer buffer = new Buffer();
+
+	private final ValueFactory f = SimpleValueFactory.getInstance();
+
+	private Literal point = f.createLiteral("POINT(23.708496093749996 37.95719224376526)", GEO.WKT_LITERAL);
+
+	private IRI unit = f.createIRI("http://www.opengis.net/def/uom/OGC/1.0/metre");
+
+	@Test
+	public void testEvaluateWithIntRadius() {
+		Value result = buffer.evaluate(f, point, f.createLiteral(1), unit);
+		assertNotNull(result);
+	}
+	
+	@Test
+	public void testEvaluateWithDoubleRadius() {
+		Value result = buffer.evaluate(f, point, f.createLiteral(1.0), unit);
+		assertNotNull(result);
+	}
+	
+	@Test
+	public void testEvaluateWithDecimalRadius() {
+		Value result = buffer.evaluate(f, point, f.createLiteral("1.0", XMLSchema.DECIMAL), unit);
+		assertNotNull(result);
+	}
+	
+	@Test(expected = ValueExprEvaluationException.class)
+	public void testEvaluateWithInvalidRadius() {
+		buffer.evaluate(f, point, f.createLiteral("foobar", XMLSchema.DECIMAL), unit);
+	}
+	
+	@Test(expected = ValueExprEvaluationException.class)
+	public void testEvaluateWithInvalidUnit() {
+		buffer.evaluate(f, point, f.createLiteral(1.0), FOAF.PERSON);
+	}
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/ConvexHullTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/ConvexHullTest.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+
+public class ConvexHullTest extends GeometricUnaryFunctionTest {
+
+	@Override
+	protected GeometricUnaryFunction testedFunction() {
+		return new ConvexHull();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DifferenceTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DifferenceTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class DifferenceTest extends GeometricBinaryFunctionTest {
+
+	@Override
+	protected GeometricBinaryFunction testedFunction() {
+		return new Difference();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DistanceTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DistanceTest.java
@@ -21,11 +21,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- *
  * @author Bart Hanssens
  */
-public class DistanceTest extends AbstractGeoSPARQLTest {
-	
+public class DistanceTest {
+
 	/**
 	 * Test distance between two cities, in meters.
 	 * 
@@ -33,37 +32,38 @@ public class DistanceTest extends AbstractGeoSPARQLTest {
 	 */
 	@Test
 	public void testDistanceAmBxl() throws IOException {
-		BindingSet bs = getBindingSet("distance.rq");
-		
+		BindingSet bs = GeoSPARQLTests.getBindingSet("distance.rq");
+
 		assertNotNull("Bindingset is null", bs);
-		
+
 		Value value = bs.getBinding("dist").getValue();
 		assertNotNull("Binded value is null", value);
-		
+
 		assertTrue("Value is not a literal", value instanceof Literal);
-		Literal l = (Literal) value;
+		Literal l = (Literal)value;
 		assertTrue("Literal not of type double", l.getDatatype().equals(XMLSchema.DOUBLE));
 
 		assertEquals("Distance Amsterdam-Brussels not correct", 173, l.doubleValue() / 1000, 0.5);
 	}
-	
+
 	/**
 	 * Test if distance between cities is the same in both directions
 	 * 
-	 * @throws IOException 
+	 * @throws IOException
 	 */
 	@Test
 	public void testDistanceSame() throws IOException {
-		BindingSet bs = getBindingSet("distance_same.rq");
+		BindingSet bs = GeoSPARQLTests.getBindingSet("distance_same.rq");
 
 		assertNotNull("Bindingset is null", bs);
 
 		Value v1 = bs.getBinding("dist1").getValue();
-		double ambxl = ((Literal) v1).doubleValue();
-		
+		double ambxl = ((Literal)v1).doubleValue();
+
 		Value v2 = bs.getBinding("dist2").getValue();
-		double bxlam = ((Literal) v2).doubleValue();
-		
-		assertEquals("Distance Amsterdam-Brussels not correct", ambxl, bxlam, 0.1);		
+		double bxlam = ((Literal)v2).doubleValue();
+
+		assertEquals("Distance Amsterdam-Brussels not correct", ambxl, bxlam, 0.1);
 	}
+
 }

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhContainsTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhContainsTest.java
@@ -21,11 +21,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- *
  * @author Bart Hanssens
  */
-public class EhContainsTest extends AbstractGeoSPARQLTest {
-	
+public class EhContainsTest extends GeometricRelationFunctionTest {
+
 	/**
 	 * Test ehContains.
 	 * 
@@ -33,17 +32,22 @@ public class EhContainsTest extends AbstractGeoSPARQLTest {
 	 */
 	@Test
 	public void testEhContainsDenver() throws IOException {
-		List<BindingSet> list = getResults("ehcontains.rq");
-		
+		List<BindingSet> list = GeoSPARQLTests.getResults("ehcontains.rq");
+
 		assertNotNull("Resultset is null", list);
 		assertEquals("Number of results must be one", 1, list.size());
 
 		Value value = list.get(0).getBinding("city").getValue();
 		assertNotNull("Binded value is null", value);
-		
+
 		assertTrue("Value is not an IRI", value instanceof IRI);
-		IRI iri = (IRI) value;
+		IRI iri = (IRI)value;
 
 		assertEquals("City is not Denver", "http://example.org/denver", iri.stringValue());
+	}
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new EhContains();
 	}
 }

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCoveredByTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCoveredByTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class EhCoveredByTest extends  GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new EhCoveredBy();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCoversTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhCoversTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class EhCoversTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new EhCovers();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhDisjointTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhDisjointTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class EhDisjointTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new EhDisjoint();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhEqualsTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhEqualsTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class EhEqualsTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new EhEquals();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhInsideTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhInsideTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class EhInsideTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new EhInside();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhMeetTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhMeetTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class EhMeetTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new EhMeet();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhOverlapTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EhOverlapTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class EhOverlapTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new EhOverlap();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EnvelopeTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/EnvelopeTest.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+
+public class EnvelopeTest extends GeometricUnaryFunctionTest {
+
+	@Override
+	protected GeometricUnaryFunction testedFunction() {
+		return new Envelope();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeoSPARQLTests.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeoSPARQLTests.java
@@ -11,7 +11,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,14 +22,11 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryResults;
-import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.util.Repositories;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 
 /**
@@ -38,9 +34,8 @@ import org.junit.BeforeClass;
  * 
  * @author Bart Hanssens
  */
-public abstract class AbstractGeoSPARQLTest {
-	private final static Repository REPO = new SailRepository(new MemoryStore());
-	private static ValueFactory F;
+public class GeoSPARQLTests {
+	private static Repository REPO;
 	
 	/**
 	 * Get the repository
@@ -48,6 +43,9 @@ public abstract class AbstractGeoSPARQLTest {
 	 * @return repository
 	 */
 	public static Repository getRepository() {
+		if (REPO == null) {
+			REPO = setupTestRepository();
+		}
 		return REPO;
 	}
 
@@ -81,16 +79,16 @@ public abstract class AbstractGeoSPARQLTest {
 	 * @throws IOException 
 	 */
 	private static String getQuery(String name) throws IOException {
-		try (InputStream is = AbstractGeoSPARQLTest.class.getResourceAsStream(name);
+		try (InputStream is = GeoSPARQLTests.class.getResourceAsStream(name);
 				BufferedReader buffer = new BufferedReader(new InputStreamReader(is))) {
             return buffer.lines().collect(Collectors.joining("\n"));
 		}
 	}
 	
-	@BeforeClass
-	public static void setUpClass() {
-		REPO.initialize();
-		F = REPO.getValueFactory();
+	private static Repository setupTestRepository() {
+		SailRepository repo = new SailRepository(new MemoryStore());
+		repo.initialize();
+		ValueFactory f = repo.getValueFactory();
 		
 		Map<String,String> cities = new HashMap<>();
 		cities.put("amsterdam", "POINT(4.9 52.37)");
@@ -102,20 +100,16 @@ public abstract class AbstractGeoSPARQLTest {
 		states.put("colorado", "POLYGON((-109.05 41, -102.05 41, -102.05 37, -109.05 37, -109.05 41))");
 		states.put("wyoming", "POLYGON((-111.05 45, -104.05 45, -104.05 41, -111.05 41, -111.05 45))");
 
-		try (RepositoryConnection conn = REPO.getConnection()) {
+		try (RepositoryConnection conn = repo.getConnection()) {
 			for(Entry<String,String> e: cities.entrySet()) {
-				IRI iri = F.createIRI("http://example.org/", e.getKey());
-				conn.add(iri, GEO.AS_WKT, F.createLiteral(e.getValue(), GEO.WKT_LITERAL));
+				IRI iri = f.createIRI("http://example.org/", e.getKey());
+				conn.add(iri, GEO.AS_WKT, f.createLiteral(e.getValue(), GEO.WKT_LITERAL));
 			}
 			for(Entry<String,String> e: states.entrySet()) {
-				IRI iri = F.createIRI("http://example.org/", e.getKey());
-				conn.add(iri, GEO.AS_WKT, F.createLiteral(e.getValue(), GEO.WKT_LITERAL));
+				IRI iri = f.createIRI("http://example.org/", e.getKey());
+				conn.add(iri, GEO.AS_WKT, f.createLiteral(e.getValue(), GEO.WKT_LITERAL));
 			}
 		}
-	}
-	
-	@AfterClass
-	public static void tearDownClass() {
-		REPO.shutDown();
+		return repo;
 	}
 }

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunctionTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunctionTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public abstract class GeometricBinaryFunctionTest {
+
+	Literal amsterdam = SimpleValueFactory.getInstance().createLiteral("POINT(4.9 52.37)", GEO.WKT_LITERAL);
+
+	Literal brussels = SimpleValueFactory.getInstance().createLiteral("POINT(4.35 50.85)", GEO.WKT_LITERAL);
+
+	protected abstract GeometricBinaryFunction testedFunction();
+	
+	@Test(expected = ValueExprEvaluationException.class)
+	public void testRelationExceptionHandling() {
+		GeometricBinaryFunction testedFunction = Mockito.spy(testedFunction());
+		Mockito.doThrow(new RuntimeException("forsooth!")).when(testedFunction).operation(Mockito.any(), Mockito.any());
+		testedFunction.evaluate(SimpleValueFactory.getInstance(), amsterdam, brussels);
+	}
+
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunctionTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunctionTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public abstract class GeometricRelationFunctionTest {
+
+	Literal amsterdam = SimpleValueFactory.getInstance().createLiteral("POINT(4.9 52.37)", GEO.WKT_LITERAL);
+
+	Literal brussels = SimpleValueFactory.getInstance().createLiteral("POINT(4.35 50.85)", GEO.WKT_LITERAL);
+
+	protected abstract GeometricRelationFunction testedFunction();
+	
+	@Test(expected = ValueExprEvaluationException.class)
+	public void testRelationExceptionHandling() {
+		GeometricRelationFunction testedFunction = Mockito.spy(testedFunction());
+		Mockito.doThrow(new RuntimeException("forsooth!")).when(testedFunction).relation(Mockito.any(), Mockito.any());
+		testedFunction.evaluate(SimpleValueFactory.getInstance(), amsterdam, brussels);
+	}
+
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunctionTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunctionTest.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public abstract class GeometricUnaryFunctionTest {
+
+	Literal amsterdam = SimpleValueFactory.getInstance().createLiteral("POINT(4.9 52.37)", GEO.WKT_LITERAL);
+
+	protected abstract GeometricUnaryFunction testedFunction();
+	
+	@Test(expected = ValueExprEvaluationException.class)
+	public void testRelationExceptionHandling() {
+		GeometricUnaryFunction testedFunction = Mockito.spy(testedFunction());
+		Mockito.doThrow(new RuntimeException("forsooth!")).when(testedFunction).operation(Mockito.any());
+		testedFunction.evaluate(SimpleValueFactory.getInstance(), amsterdam);
+	}
+
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/IntersectionTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/IntersectionTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class IntersectionTest extends GeometricBinaryFunctionTest {
+
+	@Override
+	protected GeometricBinaryFunction testedFunction() {
+		return new Intersection();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8DCTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8DCTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class RCC8DCTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new RCC8DC();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8ECTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8ECTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class RCC8ECTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new RCC8EC();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EQTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8EQTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class RCC8EQTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new RCC8EQ();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPPITest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPPITest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class RCC8NTPPITest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new RCC8NTPPI();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPPTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8NTPPTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class RCC8NTPPTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new RCC8NTPP();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8POTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8POTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class RCC8POTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new RCC8PO();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPPITest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPPITest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class RCC8TPPITest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new RCC8TPPI();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPPTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/RCC8TPPTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class RCC8TPPTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new RCC8TPP();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfContainsTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfContainsTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Bart Hanssens
  */
-public class SfContainsTest extends AbstractGeoSPARQLTest {
+public class SfContainsTest extends GeometricRelationFunctionTest {
 	
 	/**
 	 * Test sfContains.
@@ -33,7 +33,7 @@ public class SfContainsTest extends AbstractGeoSPARQLTest {
 	 */
 	@Test
 	public void testSfContainsDenver() throws IOException {
-		List<BindingSet> list = getResults("sfcontains.rq");
+		List<BindingSet> list = GeoSPARQLTests.getResults("sfcontains.rq");
 		
 		assertNotNull("Resultset is null", list);
 		assertEquals("Number of results must be one", 1, list.size());
@@ -45,5 +45,10 @@ public class SfContainsTest extends AbstractGeoSPARQLTest {
 		IRI iri = (IRI) value;
 
 		assertEquals("City is not Denver", "http://example.org/denver", iri.stringValue());
+	}
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new SfContains();
 	}
 }

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfCrossesTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfCrossesTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class SfCrossesTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new SfCrosses();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfDisjointTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfDisjointTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class SfDisjointTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new SfDisjoint();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfEqualsTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfEqualsTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class SfEqualsTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new SfEquals();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfIntersectsTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfIntersectsTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class SfIntersectsTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new SfIntersects();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfOverlapsTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfOverlapsTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class SfOverlapsTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new SfOverlaps();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfTouchesTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfTouchesTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class SfTouchesTest extends GeometricRelationFunctionTest {
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new SfTouches();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfWithinTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SfWithinTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Bart Hanssens
  */
-public class SfWithinTest extends AbstractGeoSPARQLTest {
+public class SfWithinTest extends GeometricRelationFunctionTest {
 	
 	/**
 	 * Test sfWithin
@@ -33,7 +33,7 @@ public class SfWithinTest extends AbstractGeoSPARQLTest {
 	 */
 	@Test
 	public void testDenverSfWithinColorado() throws IOException {
-		BindingSet bs = getBindingSet("sfwithin_denver.rq");
+		BindingSet bs = GeoSPARQLTests.getBindingSet("sfwithin_denver.rq");
 		
 		assertNotNull("Bindingset is null", bs);
 		
@@ -54,7 +54,7 @@ public class SfWithinTest extends AbstractGeoSPARQLTest {
 	 */
 	@Test
 	public void testBrusselsSfWithinColorado() throws IOException {
-		BindingSet bs = getBindingSet("sfwithin_brussels.rq");
+		BindingSet bs = GeoSPARQLTests.getBindingSet("sfwithin_brussels.rq");
 		
 		assertNotNull("Bindingset is null", bs);
 		
@@ -66,5 +66,10 @@ public class SfWithinTest extends AbstractGeoSPARQLTest {
 		assertTrue("Literal not of type double", l.getDatatype().equals(XMLSchema.BOOLEAN));
 
 		assertFalse("Brussels within Colorado", l.booleanValue());
+	}
+
+	@Override
+	protected GeometricRelationFunction testedFunction() {
+		return new SfWithin();
 	}
 }

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SymmetricDifferenceTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SymmetricDifferenceTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class SymmetricDifferenceTest extends GeometricBinaryFunctionTest {
+
+	@Override
+	protected GeometricBinaryFunction testedFunction() {
+		return new SymmetricDifference();
+	}
+
+}

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/UnionTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/UnionTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
+
+public class UnionTest extends GeometricBinaryFunctionTest {
+
+	@Override
+	protected GeometricBinaryFunction testedFunction() {
+		return new Union();
+	}
+
+}


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1127 and eclipse/rdf4j#1128 .

Briefly describe the changes proposed in this PR:

* fixed handling of exceptions occurring in spatial4j/jts by wrapping them as type errors
* fixed datatype conversion for geof:buffer arguments
* added extensible unit test setup to cover all geosparql functions

Apologies for pushing two fixes in one PR, but these were very closely related.
