### PR TITLE
eclipse/rdf4j#1129 use jts to produce polygon for buffered point

### DIFF
--- a/geosparql/pom.xml
+++ b/geosparql/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -27,14 +29,14 @@
 			<groupId>org.locationtech.jts</groupId>
 			<artifactId>jts-core</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-repository-sail</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
-                <dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-sail-memory</artifactId>
 			<version>${project.version}</version>
@@ -48,6 +50,12 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Buffer.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/Buffer.java
@@ -16,8 +16,11 @@ import org.eclipse.rdf4j.model.vocabulary.GEO;
 import org.eclipse.rdf4j.model.vocabulary.GEOF;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
+import org.locationtech.jts.geom.Geometry;
 import org.locationtech.spatial4j.context.SpatialContext;
+import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.impl.GeoCircle;
 
 /**
  * The GeoSPARQL {@link Function} geof:buffer, as defined in
@@ -44,7 +47,7 @@ public class Buffer implements Function {
 		IRI units = FunctionArguments.getUnits(this, args[2]);
 		double radiusDegs = FunctionArguments.convertToDegrees(radiusUom, units);
 
-		Shape buffered = geom.getBuffered(radiusDegs, geoContext);
+		Shape buffered = SpatialSupport.getSpatialAlgebra().buffer(geom, radiusDegs);
 
 		String wkt;
 		try {

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultSpatialAlgebra.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/DefaultSpatialAlgebra.java
@@ -266,4 +266,9 @@ final class DefaultSpatialAlgebra implements SpatialAlgebra {
 	public boolean rcc8ntppi(Shape s1, Shape s2) {
 		return notSupported();
 	}
+
+	@Override
+	public Shape buffer(Shape s, double distance) {
+		return s.getBuffered(distance, SpatialSupport.getSpatialContext());
+	}
 }

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/FunctionArguments.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/FunctionArguments.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
+import java.io.IOException;
 import java.text.ParseException;
 
 import org.eclipse.rdf4j.model.Literal;
@@ -21,6 +22,8 @@ import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
 
 import org.locationtech.spatial4j.context.SpatialContext;
 import org.locationtech.spatial4j.distance.DistanceUtils;
+import org.locationtech.spatial4j.exception.InvalidShapeException;
+import org.locationtech.spatial4j.io.ShapeReader;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Shape;
 
@@ -35,32 +38,36 @@ class FunctionArguments {
 	/**
 	 * Get the double value
 	 * 
-	 * @param func function
-	 * @param v value
+	 * @param func
+	 *        function
+	 * @param v
+	 *        value
 	 * @return double
-	 * @throws ValueExprEvaluationException 
+	 * @throws ValueExprEvaluationException
 	 */
-	public static double getDouble(Function func, Value v) throws ValueExprEvaluationException { 
+	public static double getDouble(Function func, Value v) throws ValueExprEvaluationException {
 		if (!(v instanceof Literal)) {
 			throw new ValueExprEvaluationException("Invalid argument for " + func.getURI() + ": " + v);
 		}
-		
+
 		try {
 			return ((Literal)v).doubleValue();
 		}
 		catch (NumberFormatException e) {
 			throw new ValueExprEvaluationException(e);
 		}
-		
+
 	}
 
 	/**
 	 * Get the string value
 	 * 
-	 * @param func function
-	 * @param v value
+	 * @param func
+	 *        function
+	 * @param v
+	 *        value
 	 * @return string
-	 * @throws ValueExprEvaluationException 
+	 * @throws ValueExprEvaluationException
 	 */
 	public static String getString(Function func, Value v) throws ValueExprEvaluationException {
 		Literal l = getLiteral(func, v, XMLSchema.STRING);
@@ -70,18 +77,23 @@ class FunctionArguments {
 	/**
 	 * Get the geo shape
 	 * 
-	 * @param func function
-	 * @param v value
+	 * @param func
+	 *        function
+	 * @param v
+	 *        value
 	 * @param context
 	 * @return shape
-	 * @throws ValueExprEvaluationException 
+	 * @throws ValueExprEvaluationException
 	 */
-	public static Shape getShape(Function func, Value v, SpatialContext context) 
-                                                                        throws ValueExprEvaluationException {
+	public static Shape getShape(Function func, Value v, SpatialContext context)
+		throws ValueExprEvaluationException
+	{
 		Literal wktLiteral = getLiteral(func, v, GEO.WKT_LITERAL);
 		try {
-			return context.readShapeFromWkt(wktLiteral.getLabel());
-		} catch (ParseException e) {
+			ShapeReader reader = context.getFormats().getWktReader();
+			return reader.read(wktLiteral.getLabel());
+		}
+		catch (IOException | InvalidShapeException | ParseException e) {
 			throw new ValueExprEvaluationException(
 					"Invalid argument for " + func.getURI() + ": " + wktLiteral, e);
 		}
@@ -90,14 +102,17 @@ class FunctionArguments {
 	/**
 	 * Get the geo point
 	 * 
-	 * @param func function
-	 * @param v value
+	 * @param func
+	 *        function
+	 * @param v
+	 *        value
 	 * @param geoContext
 	 * @return point
-	 * @throws ValueExprEvaluationException 
+	 * @throws ValueExprEvaluationException
 	 */
-	public static Point getPoint(Function func, Value v, SpatialContext geoContext) 
-                                                                        throws ValueExprEvaluationException {
+	public static Point getPoint(Function func, Value v, SpatialContext geoContext)
+		throws ValueExprEvaluationException
+	{
 		Shape p = FunctionArguments.getShape(func, v, geoContext);
 		if (!(p instanceof Point)) {
 			throw new ValueExprEvaluationException(
@@ -109,14 +124,17 @@ class FunctionArguments {
 	/**
 	 * Get the literal of a specific data type
 	 * 
-	 * @param func function
-	 * @param v value
+	 * @param func
+	 *        function
+	 * @param v
+	 *        value
 	 * @param expectedDatatype
 	 * @return literal
-	 * @throws ValueExprEvaluationException 
+	 * @throws ValueExprEvaluationException
 	 */
-	public static Literal getLiteral(Function func, Value v, IRI expectedDatatype) 
-                                                                        throws ValueExprEvaluationException {
+	public static Literal getLiteral(Function func, Value v, IRI expectedDatatype)
+		throws ValueExprEvaluationException
+	{
 		if (!(v instanceof Literal)) {
 			throw new ValueExprEvaluationException("Invalid argument for " + func.getURI() + ": " + v);
 		}
@@ -131,10 +149,12 @@ class FunctionArguments {
 	/**
 	 * Get the UoM IRI of the unit
 	 * 
-	 * @param func function
-	 * @param v value
+	 * @param func
+	 *        function
+	 * @param v
+	 *        value
 	 * @return UoM IRI
-	 * @throws ValueExprEvaluationException 
+	 * @throws ValueExprEvaluationException
 	 */
 	public static IRI getUnits(Function func, Value v) throws ValueExprEvaluationException {
 		if (!(v instanceof IRI)) {
@@ -151,23 +171,29 @@ class FunctionArguments {
 	/**
 	 * Convert degrees to another unit
 	 * 
-	 * @param degs degrees
-	 * @param units UoM IRI of the unit to convert to
+	 * @param degs
+	 *        degrees
+	 * @param units
+	 *        UoM IRI of the unit to convert to
 	 * @return converted value as a double
-	 * @throws ValueExprEvaluationException 
+	 * @throws ValueExprEvaluationException
 	 */
 	public static double convertFromDegrees(double degs, IRI units) throws ValueExprEvaluationException {
 		double v;
-		
-        if (GEOF.UOM_DEGREE.equals(units)) {
+
+		if (GEOF.UOM_DEGREE.equals(units)) {
 			v = degs;
-		} else if (GEOF.UOM_RADIAN.equals(units)) {
+		}
+		else if (GEOF.UOM_RADIAN.equals(units)) {
 			v = DistanceUtils.toRadians(degs);
-		} else if (GEOF.UOM_UNITY.equals(units)) {
+		}
+		else if (GEOF.UOM_UNITY.equals(units)) {
 			v = degs / 180.0;
-		} else if (GEOF.UOM_METRE.equals(units)) {
+		}
+		else if (GEOF.UOM_METRE.equals(units)) {
 			v = DistanceUtils.degrees2Dist(degs, DistanceUtils.EARTH_MEAN_RADIUS_KM) * 1000.0;
-		} else {
+		}
+		else {
 			throw new ValueExprEvaluationException("Invalid unit of measurement: " + units);
 		}
 		return v;
@@ -176,23 +202,29 @@ class FunctionArguments {
 	/**
 	 * Convert a value to degrees
 	 * 
-	 * @param v value
-	 * @param units UoM IRI of the unit
+	 * @param v
+	 *        value
+	 * @param units
+	 *        UoM IRI of the unit
 	 * @return degrees as a double
-	 * @throws ValueExprEvaluationException 
+	 * @throws ValueExprEvaluationException
 	 */
 	public static double convertToDegrees(double v, IRI units) throws ValueExprEvaluationException {
 		double degs;
 
 		if (GEOF.UOM_DEGREE.equals(units)) {
 			degs = v;
-		} else if (GEOF.UOM_RADIAN.equals(units)) {
+		}
+		else if (GEOF.UOM_RADIAN.equals(units)) {
 			degs = DistanceUtils.toDegrees(v);
-		} else if (GEOF.UOM_UNITY.equals(units)) {
+		}
+		else if (GEOF.UOM_UNITY.equals(units)) {
 			degs = v * 180.0;
-		} else if (GEOF.UOM_METRE.equals(units)) {
+		}
+		else if (GEOF.UOM_METRE.equals(units)) {
 			degs = DistanceUtils.dist2Degrees(v / 1000.0, DistanceUtils.EARTH_MEAN_RADIUS_KM);
-		} else {
+		}
+		else {
 			throw new ValueExprEvaluationException("Invalid unit of measurement: " + units);
 		}
 		return degs;

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/JtsSpatialAlgebra.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/JtsSpatialAlgebra.java
@@ -9,7 +9,6 @@ package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
-import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.Shape;
 import org.locationtech.spatial4j.shape.jts.JtsShapeFactory;
 
@@ -23,6 +22,11 @@ public class JtsSpatialAlgebra implements SpatialAlgebra {
 
 	public JtsSpatialAlgebra(JtsSpatialContext context) {
 		this.shapeFactory = context.getShapeFactory();
+	}
+	
+	@Override
+	public Shape buffer(Shape s, double distance) {
+		return shapeFactory.makeShapeFromGeometry(shapeFactory.getGeometryFrom(s).buffer(distance));
 	}
 
 	public Shape convexHull(Shape s) {
@@ -182,5 +186,7 @@ public class JtsSpatialAlgebra implements SpatialAlgebra {
 	public boolean rcc8ntppi(Shape s1, Shape s2) {
 		return relate(s1, s2, "TTTFFTFFT");
 	}
+
+
 
 }

--- a/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialAlgebra.java
+++ b/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/SpatialAlgebra.java
@@ -11,6 +11,8 @@ import org.locationtech.spatial4j.shape.Shape;
 
 public interface SpatialAlgebra {
 
+	Shape buffer(Shape s, double distance);
+	
 	Shape convexHull(Shape s);
 
 	Shape boundary(Shape s);

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/BufferTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/BufferTest.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.function.geosparql;
 
 import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -38,24 +39,32 @@ public class BufferTest {
 		Value result = buffer.evaluate(f, point, f.createLiteral(1), unit);
 		assertNotNull(result);
 	}
-	
+
 	@Test
 	public void testEvaluateWithDoubleRadius() {
 		Value result = buffer.evaluate(f, point, f.createLiteral(1.0), unit);
 		assertNotNull(result);
 	}
-	
+
 	@Test
 	public void testEvaluateWithDecimalRadius() {
 		Value result = buffer.evaluate(f, point, f.createLiteral("1.0", XMLSchema.DECIMAL), unit);
 		assertNotNull(result);
 	}
-	
+
+	@Test
+	public void resultIsPolygonWKT() {
+		Literal result = (Literal)buffer.evaluate(f, point, f.createLiteral(1), unit);
+		assertNotNull(result);
+		assertThat(result.getDatatype()).isEqualTo(GEO.WKT_LITERAL);
+		assertThat(result.getLabel()).startsWith( "POLYGON ((23.708505");
+	}
+
 	@Test(expected = ValueExprEvaluationException.class)
 	public void testEvaluateWithInvalidRadius() {
 		buffer.evaluate(f, point, f.createLiteral("foobar", XMLSchema.DECIMAL), unit);
 	}
-	
+
 	@Test(expected = ValueExprEvaluationException.class)
 	public void testEvaluateWithInvalidUnit() {
 		buffer.evaluate(f, point, f.createLiteral(1.0), FOAF.PERSON);


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1129 .

Briefly describe the changes proposed in this PR:

* move buffer calculation to SpatialAlgebra impl
* let default jts spatialalgebra use geometry to buffer, and produce a polygon instead of a circle

