### PR TITLE
Partial rollback: try-with-resources fails on generic exception

### DIFF
--- a/spin/src/main/java/org/eclipse/rdf4j/spin/SpinParser.java
+++ b/spin/src/main/java/org/eclipse/rdf4j/spin/SpinParser.java
@@ -268,8 +268,9 @@ public class SpinParser {
 		throws RDF4JException
 	{
 		Map<IRI, RuleProperty> rules = new HashMap<IRI, RuleProperty>();
-		try (CloseableIteration<? extends IRI, ? extends RDF4JException> rulePropIter = TripleSources.getSubjectURIs(
-			RDFS.SUBPROPERTYOF, SPIN.RULE_PROPERTY, store)) {
+		CloseableIteration<? extends IRI, ? extends RDF4JException> rulePropIter = TripleSources.getSubjectURIs(
+			RDFS.SUBPROPERTYOF, SPIN.RULE_PROPERTY, store);
+		try {
 			while (rulePropIter.hasNext()) {
 				IRI ruleProp = rulePropIter.next();
 				RuleProperty ruleProperty = new RuleProperty(ruleProp);
@@ -282,6 +283,8 @@ public class SpinParser {
 
 				rules.put(ruleProp, ruleProperty);
 			}
+		} finally {
+			rulePropIter.close();
 		}
 		return rules;
 	}
@@ -290,11 +293,14 @@ public class SpinParser {
 		throws RDF4JException
 	{
 		List<IRI> nextRules = new ArrayList<IRI>();
-		try (CloseableIteration<? extends IRI, ? extends RDF4JException> iter = TripleSources.getObjectURIs(ruleProp,
-			SPIN.NEXT_RULE_PROPERTY_PROPERTY, store)) {
+		CloseableIteration<? extends IRI, ? extends RDF4JException> iter = TripleSources.getObjectURIs(ruleProp,
+			SPIN.NEXT_RULE_PROPERTY_PROPERTY, store);
+		try {
 			while (iter.hasNext()) {
 				nextRules.add(iter.next());
 			}
+		} finally {
+			iter.close();
 		}
 		return nextRules;
 	}
@@ -401,8 +407,9 @@ public class SpinParser {
 		Boolean isQueryElseTemplate = null;
 		Set<IRI> possibleQueryTypes = new HashSet<IRI>();
 		Set<IRI> possibleTemplates = new HashSet<IRI>();
-		try (CloseableIteration<? extends IRI, ? extends RDF4JException> typeIter = TripleSources.getObjectURIs(
-			queryResource, RDF.TYPE, store)) {
+		CloseableIteration<? extends IRI, ? extends RDF4JException> typeIter = TripleSources.getObjectURIs(
+			queryResource, RDF.TYPE, store);
+		try {
 			while (typeIter.hasNext()) {
 				IRI type = typeIter.next();
 				if (isQueryElseTemplate == null && SPIN.TEMPLATES_CLASS.equals(type)) {
@@ -420,6 +427,8 @@ public class SpinParser {
 					possibleTemplates.add(type);
 				}
 			}
+		} finally {
+			typeIter.close();
 		}
 
 		ParsedOperation parsedOp;
@@ -526,14 +535,17 @@ public class SpinParser {
 		throws RDF4JException
 	{
 		Set<IRI> possibleTmplTypes = new HashSet<IRI>();
-		try (CloseableIteration<? extends IRI, ? extends RDF4JException> typeIter = TripleSources.getObjectURIs(
-			tmplUri, RDF.TYPE, store)) {
+		CloseableIteration<? extends IRI, ? extends RDF4JException> typeIter = TripleSources.getObjectURIs(
+			tmplUri, RDF.TYPE, store);
+		try {
 			while (typeIter.hasNext()) {
 				IRI type = typeIter.next();
 				if (TEMPLATE_TYPES.contains(type)) {
 					possibleTmplTypes.add(type);
 				}
 			}
+		} finally {
+			typeIter.close();
 		}
 
 		if (possibleTmplTypes.isEmpty()) {
@@ -663,8 +675,9 @@ public class SpinParser {
 	private void parseArguments(IRI moduleUri, TripleSource store, Map<IRI, Argument> args)
 		throws RDF4JException
 	{
-		try (CloseableIteration<? extends Resource, ? extends RDF4JException> argIter = TripleSources.getObjectResources(
-			moduleUri, SPIN.CONSTRAINT_PROPERTY, store)) {
+		CloseableIteration<? extends Resource, ? extends RDF4JException> argIter = TripleSources.getObjectResources(
+			moduleUri, SPIN.CONSTRAINT_PROPERTY, store);
+		try {
 			while (argIter.hasNext()) {
 				Resource possibleArg = argIter.next();
 				Statement argTmpl = TripleSources.single(possibleArg, RDF.TYPE, SPL.ARGUMENT_TEMPLATE, store);
@@ -678,6 +691,8 @@ public class SpinParser {
 					args.put(argUri, new Argument(argUri, (IRI)valueType, optional, defaultValue));
 				}
 			}
+		} finally {
+			argIter.close();
 		}
 	}
 

--- a/spin/src/main/java/org/eclipse/rdf4j/spin/function/EvalFunction.java
+++ b/spin/src/main/java/org/eclipse/rdf4j/spin/function/EvalFunction.java
@@ -126,8 +126,9 @@ public class EvalFunction extends AbstractSpinFunction implements Function {
 	private boolean isQuery(Resource r, TripleSource store)
 		throws RDF4JException
 	{
-		try (CloseableIteration<? extends URI, ? extends RDF4JException> typeIter = TripleSources.getObjectURIs(r,
-			RDF.TYPE, store)) {
+		CloseableIteration<? extends URI, ? extends RDF4JException> typeIter = TripleSources.getObjectURIs(r,
+			RDF.TYPE, store);
+		try {
 			while (typeIter.hasNext()) {
 				URI type = typeIter.next();
 				if (SP.SELECT_CLASS.equals(type) || SP.ASK_CLASS.equals(type)
@@ -136,6 +137,8 @@ public class EvalFunction extends AbstractSpinFunction implements Function {
 					return true;
 				}
 			}
+		} finally {
+			typeIter.close();
 		}
 
 		return false;


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1092 .

Briefly describe the changes proposed in this PR:

* Use try-finally instead of try-with-resources, (some ?) JDK doesn't compile code with generic exception parameters in try-with-resources blocks
