### PR TITLE
eclipse/rdf4j#78 fix join optimizer messing with bind/subselect combo

### DIFF
--- a/evaluation/pom.xml
+++ b/evaluation/pom.xml
@@ -59,6 +59,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mapdb</groupId>
@@ -67,6 +68,11 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
         <build>

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryJoinOptimizer.java
@@ -92,15 +92,15 @@ public class QueryJoinOptimizer implements QueryOptimizer {
 				// Reorder the subselects and extensions to a more optimal sequence
 				List<TupleExpr> priorityArgs = new ArrayList<TupleExpr>(joinArgs.size());
 
-				// first get all subselects and order them
-				List<TupleExpr> orderedSubselects = reorderSubselects(getSubSelects(joinArgs));
-				joinArgs.removeAll(orderedSubselects);
-				priorityArgs.addAll(orderedSubselects);
-
-				// second get all extensions (BIND clause)
+				// get all extensions (BIND clause)
 				List<Extension> orderedExtensions = getExtensions(joinArgs);
 				joinArgs.removeAll(orderedExtensions);
 				priorityArgs.addAll(orderedExtensions);
+				
+				// get all subselects and order them
+				List<TupleExpr> orderedSubselects = reorderSubselects(getSubSelects(joinArgs));
+				joinArgs.removeAll(orderedSubselects);
+				priorityArgs.addAll(orderedSubselects);
 
 				// We order all remaining join arguments based on cardinality and
 				// variable frequency statistics


### PR DESCRIPTION

This PR addresses GitHub issue: eclipse/rdf4j#78 .

Briefly describe the changes proposed in this PR:

* ensure QueryJoinOptimizer does not mess up order when a BIND clause is combined with a subselect
* added regression test

