### PR TITLE
Updated Apache Commons dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,27 +248,22 @@
 			<dependency>
 				<groupId>commons-cli</groupId>
 				<artifactId>commons-cli</artifactId>
-				<version>1.2</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-dbcp</groupId>
-				<artifactId>commons-dbcp</artifactId>
 				<version>1.4</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-fileupload</groupId>
 				<artifactId>commons-fileupload</artifactId>
-				<version>1.3.1</version>
+				<version>1.3.3</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.5</version>
+				<version>2.6</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
-				<version>1.10</version>
+				<version>1.11</version>
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1096 .

Briefly describe the changes proposed in this PR:

* Removed unused Apache Commons DBCP
* Upgraded Apache Commons FileUpload / IO / Codec / CLI
