### PR TITLE
eclipse/rdf4j#1168 fix handling of language tags in concat function

### DIFF
--- a/evaluation/pom.xml
+++ b/evaluation/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -29,7 +31,8 @@
 			<artifactId>rdf4j-query</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<!-- FIXME: Move SPARQLFederatedService out to another module to avoid the following dependency -->
+		<!-- FIXME: Move SPARQLFederatedService out to another module to avoid 
+			the following dependency -->
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-repository-sparql</artifactId>
@@ -45,7 +48,7 @@
 			<artifactId>rdf4j-util</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
@@ -59,7 +62,14 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.mapdb</groupId>
 			<artifactId>mapdb</artifactId>
@@ -69,12 +79,12 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 	</dependencies>
-        <build>
-                <plugins>
-                        <plugin>
-                                <groupId>com.github.siom79.japicmp</groupId>
-                                <artifactId>japicmp-maven-plugin</artifactId>
-                        </plugin>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/Concat.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/Concat.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.model.vocabulary.FN;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.function.Function;
+import org.eclipse.rdf4j.query.algebra.evaluation.util.QueryEvaluationUtil;
 
 /**
  * The SPARQL built-in {@link Function} CONCAT, as defined in
@@ -36,23 +37,25 @@ public class Concat implements Function {
 		}
 
 		StringBuilder concatBuilder = new StringBuilder();
-		String languageTag = null;
-
+		String commonLanguageTag = null;
 		boolean useLanguageTag = true;
-		boolean useDatatype = true;
 
 		for (Value arg : args) {
 			if (arg instanceof Literal) {
 				Literal lit = (Literal)arg;
 
+				if (!QueryEvaluationUtil.isStringLiteral(lit)) {
+					throw new ValueExprEvaluationException("unexpected datatype for CONCAT operand: " + lit);
+				}
+				
 				// verify that every literal argument has the same language tag. If
 				// not, the operator result should not use a language tag.
 				if (useLanguageTag && Literals.isLanguageLiteral(lit)) {
-					if (languageTag == null) {
-						languageTag = lit.getLanguage().get();
+					if (commonLanguageTag == null) {
+						commonLanguageTag = lit.getLanguage().get();
 					}
-					else if (!languageTag.equals(lit.getLanguage())) {
-						languageTag = null;
+					else if (!commonLanguageTag.equals(lit.getLanguage().orElse(null))) {
+						commonLanguageTag = null;
 						useLanguageTag = false;
 					}
 				}
@@ -60,32 +63,18 @@ public class Concat implements Function {
 					useLanguageTag = false;
 				}
 
-				// check datatype: concat only expects plain, language-tagged or
-				// string-typed literals. If all arguments are of type xsd:string,
-				// the result also should be,
-				// otherwise the result will not have a datatype.
-				if (lit.getDatatype() == null) {
-					useDatatype = false;
-				}
-				else if (!lit.getDatatype().equals(XMLSchema.STRING)) {
-					throw new ValueExprEvaluationException("unexpected data type for concat operand: " + arg);
-				}
-
 				concatBuilder.append(lit.getLabel());
 			}
 			else {
 				throw new ValueExprEvaluationException(
-						"unexpected argument type for concat operator: " + arg);
+						"unexpected argument type for CONCAT operator: " + arg);
 			}
 		}
 
 		Literal result = null;
 
-		if (useDatatype) {
-			result = valueFactory.createLiteral(concatBuilder.toString(), XMLSchema.STRING);
-		}
-		else if (useLanguageTag) {
-			result = valueFactory.createLiteral(concatBuilder.toString(), languageTag);
+		if (useLanguageTag) {
+			result = valueFactory.createLiteral(concatBuilder.toString(), commonLanguageTag);
 		}
 		else {
 			result = valueFactory.createLiteral(concatBuilder.toString());

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/ConcatTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/ConcatTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.BooleanLiteral;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public class ConcatTest {
+
+	private Concat concatFunc;
+
+	private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+	private static final Literal foo = vf.createLiteral("foo");
+
+	private static final Literal bar = vf.createLiteral("bar");
+
+	private static final Literal foo_en = vf.createLiteral("foo", "en");
+
+	private static final Literal bar_en = vf.createLiteral("bar", "en");
+
+	private static final Literal foo_nl = vf.createLiteral("foo", "nl");
+
+	@Before
+	public void setUp()
+		throws Exception
+	{
+		concatFunc = new Concat();
+	}
+
+	@Test
+	public void stringLiteralHandling() {
+		Literal result = concatFunc.evaluate(vf, foo, bar);
+
+		assertThat(result.stringValue()).isEqualTo("foobar");
+		assertThat(result.getDatatype()).isEqualTo(XMLSchema.STRING);
+		assertThat(result.getLanguage().isPresent()).isFalse();
+	}
+
+	@Test
+	public void commonLanguageLiteralHandling() {
+		Literal result = concatFunc.evaluate(vf, foo_en, bar_en);
+
+		assertThat(result.stringValue()).isEqualTo("foobar");
+		assertThat(result.getDatatype()).isEqualTo(RDF.LANGSTRING);
+		assertThat(result.getLanguage().get()).isEqualTo("en");
+
+	}
+	
+	@Test
+	public void mixedLanguageLiteralHandling() {
+		Literal result = concatFunc.evaluate(vf, foo_nl, bar_en);
+
+		assertThat(result.stringValue()).isEqualTo("foobar");
+		assertThat(result.getDatatype()).isEqualTo(XMLSchema.STRING);
+		assertThat(result.getLanguage().isPresent()).isFalse();
+	}
+
+	@Test
+	public void mixedLiteralHandling() {
+		Literal result = concatFunc.evaluate(vf, foo, bar_en);
+
+		assertThat(result.stringValue()).isEqualTo("foobar");
+		assertThat(result.getDatatype()).isEqualTo(XMLSchema.STRING);
+		assertThat(result.getLanguage().isPresent()).isFalse();
+	}
+
+	@Test
+	public void nonStringLiteralHandling() {
+		try {
+			concatFunc.evaluate(vf, RDF.TYPE, BooleanLiteral.TRUE);
+			fail("CONCAT expected to fail on non-stringliteral argument");
+		}
+		catch (ValueExprEvaluationException e) {
+			// ignore, expected
+		}
+	}
+	
+	@Test
+	public void nonLiteralHandling() {
+		try {
+			concatFunc.evaluate(vf, RDF.TYPE, bar_en);
+			fail("CONCAT expected to fail on non-literal argument");
+		}
+		catch (ValueExprEvaluationException e) {
+			// ignore, expected
+		}
+	}
+
+}


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1168 .

Briefly describe the changes proposed in this PR:

* remove too-strict validation of literal datatypes
* added regression tests

