### PR TITLE
Replace some REGEX calls that can be expressed as string functions

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizer.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizer.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FN;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.Compare;
+import org.eclipse.rdf4j.query.algebra.FunctionCall;
+import org.eclipse.rdf4j.query.algebra.Regex;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.ValueConstant;
+import org.eclipse.rdf4j.query.algebra.ValueExpr;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
+
+/**
+ * A query optimizer that replaces REGEX with {@link FunctionCall}s that are
+ * equivalent operators
+ *
+ * @author Jerven Bolleman
+ */
+public class RegexAsStringFunctionOptimizer implements QueryOptimizer {
+
+    private final ValueFactory vf;
+
+    public RegexAsStringFunctionOptimizer(ValueFactory vf) {
+        this.vf = vf;
+    }
+
+    /**
+     * Applies generally applicable optimizations to the supplied query:
+     * variable assignments are inlined.
+     */
+    public void optimize(TupleExpr tupleExpr, Dataset dataset, BindingSet bindings) {
+        tupleExpr.visit(new RegexAsStringFunctionVisitor());
+    }
+
+    protected class RegexAsStringFunctionVisitor
+            extends AbstractQueryModelVisitor<RuntimeException> {
+
+        @Override
+        public void meet(Regex node) {
+            final ValueExpr flagsArg = node.getFlagsArg();
+            if (flagsArg == null || flagsArg.toString().isEmpty()) {
+                //if we have no flags then we can not be in case insensitive mode
+                if (node.getPatternArg() instanceof ValueConstant && node.getArg() instanceof Var) {
+                    ValueConstant vc = (ValueConstant) node.getPatternArg();
+                    String regex = vc.getValue().stringValue();
+                    final boolean anchoredAtStart = regex.startsWith("^");
+                    final boolean anchoredAtEnd = regex.endsWith("$");
+
+                    if (anchoredAtStart && anchoredAtEnd) {
+                        equalsCandidate(node, regex);
+                    } else if (anchoredAtStart) {
+                        strstartsCandidate(node, regex);
+                    } else if (anchoredAtEnd) {
+                        strendsCandidate(node, regex);
+                    } else {
+                        containsCandidate(node, regex);
+                    }
+                }
+            }
+            super.meet(node);
+        }
+
+        private void containsCandidate(Regex node, String potential) {
+            if (plain(potential)) {
+                node.replaceWith(new FunctionCall(FN.CONTAINS.stringValue(), node.getArg(), node.getPatternArg()));
+            }
+        }
+
+        //If we have one of these chars it is likely to be an real regex.
+        //If we are willing to peek in a Pattern object we could be sure
+        //this seems a valid start with no regexes marked as simple strings
+        private boolean plain(String potential) {
+            for (int not : new char[]{'?', '*', '+', '{', '|', '\\', '.', '[', ']', '&', '(',')'}) {
+                if (potential.indexOf(not) != -1) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void strendsCandidate(Regex node, String regex) {
+            final String potential = regex.substring(0, regex.length() - 1);
+            if (plain(potential)) {
+                ValueConstant vc = new ValueConstant(vf.createLiteral(potential));
+                node.replaceWith(new FunctionCall(FN.ENDS_WITH.stringValue(), node.getArg(), vc));
+            }
+        }
+
+        private void strstartsCandidate(Regex node, String regex) {
+            final String potential = regex.substring(1, regex.length());
+            if (plain(potential)) {
+                ValueConstant vc = new ValueConstant(vf.createLiteral(potential));
+                node.replaceWith(new FunctionCall(FN.STARTS_WITH.stringValue(), node.getArg(), vc));
+            }
+        }
+
+        private void equalsCandidate(Regex node, String regex) {
+            final String potential = regex.substring(1, regex.length() - 1);
+            if (plain(potential)) {
+                ValueConstant vc = new ValueConstant(vf.createLiteral(potential));
+                node.replaceWith(new Compare(node.getArg(), vc, Compare.CompareOp.EQ));
+            }
+        }
+    }
+}

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizierTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizierTest.java
@@ -1,0 +1,133 @@
+/** *****************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ ****************************************************************************** */
+
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import static org.junit.Assert.assertEquals;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.UnsupportedQueryLanguageException;
+import org.eclipse.rdf4j.query.algebra.QueryModelNode;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.eclipse.rdf4j.query.parser.QueryParserUtil;
+import org.junit.Test;
+
+/**
+ * Tests to make sure the RegexAsStringFunctionOptomizer behaves.
+ *
+ * @author Jerven Bolleman
+ */
+public class RegexAsStringFunctionOptimizierTest {
+
+    @Test
+    public void testEqualsTerm()
+            throws MalformedQueryException {
+        String unoptimizedQuery
+                = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(?o, '^a$'))}";
+        String optimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(?o =  'a')}";
+        testOptimizer(optimizedQuery, unoptimizedQuery);
+    }
+
+    @Test
+    public void testStrStartsTerm()
+            throws MalformedQueryException {
+        String unoptimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(?o, '^a'))}";
+        String optimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(strStarts(?o, 'a'))}";
+
+        testOptimizer(optimizedQuery, unoptimizedQuery);
+    }
+
+    @Test
+    public void testStrEndsTerm()
+            throws MalformedQueryException {
+        String unoptimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(?o, 'a$'))}";
+        String optimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(strEnds(?o, 'a'))}";
+
+        testOptimizer(optimizedQuery, unoptimizedQuery);
+    }
+
+    @Test
+    public void testContains()
+            throws MalformedQueryException {
+        String unoptimizedQuery
+                = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(?o, 'a'))}";
+        String optimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(contains(?o, 'a'))}";
+        testOptimizer(optimizedQuery, unoptimizedQuery);
+    }
+
+    @Test
+    public void testContainsWithDollar()
+            throws MalformedQueryException {
+        String unoptimizedQuery
+                = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX($o, 'a'))}";
+        String optimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(contains(?o, 'a'))}";
+        testOptimizer(optimizedQuery, unoptimizedQuery);
+    }
+
+    @Test
+    public void testContainsWithStrangeSpacingAndCaptials()
+            throws MalformedQueryException {
+        String unoptimizedQuery
+                = "SELECT ?o WHERE {?s ?p ?o . FILTER(REgeX(  $o , \"a\" ))}";
+        String optimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(contains(?o,  'a'))}";
+        testOptimizer(optimizedQuery, unoptimizedQuery);
+    }
+
+    @Test
+    public void testNotContains()
+            throws MalformedQueryException {
+        String unoptimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(?o, 'a', 'i'))}";
+
+        testOptimizer(unoptimizedQuery, unoptimizedQuery);
+    }
+
+    @Test
+    public void testRealRegexDoesNotRedirect() {
+
+        String unoptimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(?o, 'a*'))}";
+
+        testOptimizer(unoptimizedQuery, unoptimizedQuery);
+        unoptimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(?o, 'a+'))}";
+
+        testOptimizer(unoptimizedQuery, unoptimizedQuery);
+        unoptimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(?o, 'a[abc]'))}";
+
+        testOptimizer(unoptimizedQuery, unoptimizedQuery);
+        unoptimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(?o, 'a&&b'))}";
+
+        testOptimizer(unoptimizedQuery, unoptimizedQuery);
+    }
+
+    @Test
+    public void testContainsAsIs()
+            throws MalformedQueryException {
+        String unoptimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(contains(?o, 'a*'))}";
+
+        testOptimizer(unoptimizedQuery, unoptimizedQuery);
+    }
+
+    private void testOptimizer(String expectedQuery, String actualQuery)
+            throws MalformedQueryException, UnsupportedQueryLanguageException {
+        ParsedQuery pq = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, actualQuery, null);
+        QueryOptimizer opt = new RegexAsStringFunctionOptimizer(SimpleValueFactory.getInstance());
+        QueryRoot optRoot = new QueryRoot(pq.getTupleExpr());
+        opt.optimize(optRoot, null, null);
+
+        ParsedQuery expectedParsedQuery = QueryParserUtil.parseQuery(QueryLanguage.SPARQL, expectedQuery,
+                null);
+        QueryRoot root = new QueryRoot(expectedParsedQuery.getTupleExpr());
+        assertQueryModelTrees(root, optRoot);
+    }
+
+    private void assertQueryModelTrees(QueryModelNode expected, QueryModelNode actual) {
+        assertEquals(expected, actual);
+    }
+}

--- a/sail-base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
+++ b/sail-base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
@@ -40,6 +40,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.IterativeEvaluationOptimi
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.OrderLimitOptimizer;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryJoinOptimizer;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryModelNormalizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.RegexAsStringFunctionOptimizer;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.SameTermFilterOptimizer;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory;
@@ -240,6 +241,8 @@ public abstract class SailSourceConnection extends NotifyingSailConnectionBase
 
 			new BindingAssigner().optimize(tupleExpr, dataset, bindings);
 			new ConstantOptimizer(strategy).optimize(tupleExpr, dataset, bindings);
+			//The regex as string function optimizer works better if the constants are resolved
+			new RegexAsStringFunctionOptimizer(vf).optimize(tupleExpr, dataset, bindings);
 			new CompareOptimizer().optimize(tupleExpr, dataset, bindings);
 			new ConjunctiveConstraintSplitter().optimize(tupleExpr, dataset, bindings);
 			new DisjunctiveConstraintOptimizer().optimize(tupleExpr, dataset, bindings);


### PR DESCRIPTION
Addresses issue: eclipse/rdf4j#1199

This is a trivial query optimizer which can help public endpoints where cheaper string functions (that are easier to further optimize) instead of relatively expensive regex calls. (even if the regex is otherwise trivial in runtime costs).

The regex pattern is tested to make sure it does not contain any of the control characters and is case sensitive. This could be improved to avoid false negatives by inspecting the Pattern object itself. However,
that needs reflection and I think that is not welcome.

This pull request just adds the optimizer, it does not enable it any repository.

There is an copyright assignment from me (and my employer) to Aduna on file. Arranging a new one for RDF4J will take a lot of time, so I hope this acceptable as is.
