### PR TITLE
eclipse/rdf4j#1196 temporarily disable tests involving ESIntegTestCase

### DIFF
--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchIndexTest.java
@@ -41,10 +41,12 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.SuppressLocalMode;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 @ClusterScope(numDataNodes = 1)
 @SuppressLocalMode
+@Ignore("timeouts on JIPP due to ES cluster being spun up - see https://github.com/eclipse/rdf4j/issues/1196")
 public class ElasticsearchIndexTest extends ESIntegTestCase {
 
 	private static final ValueFactory vf = SimpleValueFactory.getInstance();

--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailGeoSPARQLTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 @ClusterScope(numDataNodes = 1)
 @SuppressLocalMode
+@Ignore("timeouts on JIPP due to ES cluster being spun up - see https://github.com/eclipse/rdf4j/issues/1196")
 public class ElasticsearchSailGeoSPARQLTest extends ESIntegTestCase {
 
 	AbstractLuceneSailGeoSPARQLTest delegateTest;

--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailIndexedPropertiesTest.java
@@ -23,10 +23,12 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.SuppressLocalMode;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 @ClusterScope(numDataNodes = 1)
 @SuppressLocalMode
+@Ignore("timeouts on JIPP due to ES cluster being spun up - see https://github.com/eclipse/rdf4j/issues/1196")
 public class ElasticsearchSailIndexedPropertiesTest extends ESIntegTestCase {
 
 	AbstractLuceneSailIndexedPropertiesTest delegateTest;

--- a/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
+++ b/compliance/elasticsearch/src/test/java/org/eclipse/rdf4j/sail/elasticsearch/ElasticsearchSailTest.java
@@ -23,10 +23,12 @@ import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.SuppressLocalMode;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 @ClusterScope(numDataNodes = 1)
 @SuppressLocalMode
+@Ignore("timeouts on JIPP due to ES cluster being spun up - see https://github.com/eclipse/rdf4j/issues/1196")
 public class ElasticsearchSailTest extends ESIntegTestCase {
 
 	AbstractLuceneSailTest delegateTest;


### PR DESCRIPTION
Signed-off-by: Jeen Broekstra <jeen.broekstra@gmail.com>


This PR addresses GitHub issue: eclipse/rdf4j#1196 .

Briefly describe the changes proposed in this PR:

* temporarily disable all tests involving spinning up an ES cluster

Clearly this is an undesirable situation but the Jenkins instance is a shared resource and can't handle these tests. An option is to configure our JIPP to use a slave node (see link in iissue comments) but I need some time to get my head around that. Until then, I'd like less noise from Jenkins and less build failures. 
