### PR TITLE
Upgrade to latest Mockito 2

### DIFF
--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunctionTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricBinaryFunctionTest.java
@@ -14,7 +14,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public abstract class GeometricBinaryFunctionTest {

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunctionTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricRelationFunctionTest.java
@@ -14,7 +14,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public abstract class GeometricRelationFunctionTest {

--- a/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunctionTest.java
+++ b/geosparql/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/geosparql/GeometricUnaryFunctionTest.java
@@ -14,7 +14,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public abstract class GeometricUnaryFunctionTest {

--- a/pom.xml
+++ b/pom.xml
@@ -484,10 +484,9 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<!-- needs extra dependencies: objenesis & hamcrest -->
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.10.19</version>
+				<version>2.23.4</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -496,7 +495,6 @@
 				<version>3.9.1</version>
 				<scope>test</scope>
 			</dependency>
-
 			<dependency>
 				<groupId>com.github.jsonld-java</groupId>
 				<artifactId>jsonld-java</artifactId>
@@ -799,6 +797,9 @@
 							<rules>
 								<enforceBytecodeVersion>
 									<maxJdkVersion>1.8</maxJdkVersion>
+									<ignoreClasses>
+										<ignoreClass>META-INF/**/module-info</ignoreClass>
+									</ignoreClasses>
 									<excludes>
 										<exclude>org.apache.logging.log4j:log4j-api</exclude>
 										<exclude>org.elasticsearch:elasticsearch</exclude>
@@ -813,7 +814,7 @@
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.0-beta-6</version>
+						<version>1.0</version>
 					</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1214 .

Briefly describe the changes proposed in this PR:

* Use Mockito 2.23 instead of 1.x
* Replacing deprecated Mockito 1.x imports by 2.x counterparts
* Ignore JDK 9 module-info.java in third party code (Mockito now uses bytebuddy) when enforcing JDK 8 code

