### PR TITLE
Remove unused cglib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,12 +424,6 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
-
-			<dependency>
-				<groupId>cglib</groupId>
-				<artifactId>cglib</artifactId>
-				<version>3.1</version>
-			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1217 .

Briefly describe the changes proposed in this PR:

* Remove unused cglib dependency from pom.xml