### PR TITLE
GH-1225 marked inferencer deprecated

### DIFF
--- a/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencer.java
+++ b/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencer.java
@@ -17,7 +17,11 @@ import org.eclipse.rdf4j.sail.inferencer.InferencerConnection;
  * <a href="http://www.w3.org/TR/2004/REC-rdf-mt-20040210/">RDF Semantics Recommendation (10 February
  * 2004)</a>. This inferencer can be used to add RDF Schema semantics to any Sail that returns
  * {@link InferencerConnection}s from their {@link Sail#getConnection()} method.
+ * 
+ * @deprecated since 2.5. This inferencer implementation will be phased out. Consider switching to the
+ *             {@link SchemaCachingRDFSInferencer} instead.
  */
+@Deprecated
 public class ForwardChainingRDFSInferencer extends AbstractForwardChainingInferencer {
 	/*--------------*
 	 * Constructors *

--- a/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencerConnection.java
+++ b/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/ForwardChainingRDFSInferencerConnection.java
@@ -26,7 +26,11 @@ import org.eclipse.rdf4j.sail.inferencer.InferencerConnection;
  * <a href="http://www.w3.org/TR/2004/REC-rdf-mt-20040210/">RDF Semantics Recommendation (10 February
  * 2004)</a>. This inferencer can be used to add RDF Schema semantics to any Sail that returns
  * {@link InferencerConnection}s from their {@link Sail#getConnection()} method.
+ * 
+ * @deprecated since 2.5. This inferencer implementation will be phased out. Consider switching to the
+ *             {@link SchemaCachingRDFSInferencer} instead.
  */
+@Deprecated
 class ForwardChainingRDFSInferencerConnection extends AbstractForwardChainingInferencerConnection {
 	/*-----------*
 	 * Variables *

--- a/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/ForwardChainingRDFSInferencerConfig.java
+++ b/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/ForwardChainingRDFSInferencerConfig.java
@@ -13,6 +13,7 @@ import org.eclipse.rdf4j.sail.config.SailImplConfig;
 /**
  * @author Arjohn Kampman
  */
+@Deprecated
 public class ForwardChainingRDFSInferencerConfig extends AbstractDelegatingSailImplConfig {
 
 	public ForwardChainingRDFSInferencerConfig() {

--- a/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/ForwardChainingRDFSInferencerFactory.java
+++ b/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/ForwardChainingRDFSInferencerFactory.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.sail.inferencer.fc.ForwardChainingRDFSInferencer;
  * 
  * @author Arjohn Kampman
  */
+@Deprecated
 public class ForwardChainingRDFSInferencerFactory implements SailFactory {
 
 	/**


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1225 .

Briefly describe the changes proposed in this PR:

* deprecated `ForwardChainingRDFSInferencer` and related code.

Note that the SchemaCachingInferencer currently has no corresponding Config and Factory classes yet. They're easy to add though, 