### PR TITLE
SchemaCachingInferencer as the default RDFS reasoner

### DIFF
--- a/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/SchemaCachingRDFSInferencerRDFSchemaMemoryRepositoryConnectionTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/SchemaCachingRDFSInferencerRDFSchemaMemoryRepositoryConnectionTest.java
@@ -38,7 +38,6 @@ public class SchemaCachingRDFSInferencerRDFSchemaMemoryRepositoryConnectionTest
 	@Override
 	protected Repository createRepository() {
 		SchemaCachingRDFSInferencer sail = new SchemaCachingRDFSInferencer(new MemoryStore(), true);
-		sail.setAddInferredStatementsToDefaultContext(false);
 		return new SailRepository(sail);
 	}
 

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/sail/fc/InferredContextTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/sail/fc/InferredContextTest.java
@@ -32,7 +32,6 @@ public class InferredContextTest {
 		sail.initialize();
 		sail.setAddInferredStatementsToDefaultContext(true);
 
-
 		try (SchemaCachingRDFSInferencerConnection connection = sail.getConnection()) {
 			connection.begin();
 			connection.addStatement(bNode, RDF.TYPE, type, context);

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/sail/fc/SchemaCachingRDFSInferencerIsolationLevelTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/sail/fc/SchemaCachingRDFSInferencerIsolationLevelTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.fc;
+
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.SailIsolationLevelTest;
+import org.eclipse.rdf4j.sail.inferencer.fc.SchemaCachingRDFSInferencer;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+
+/**
+ * An extension of {@link SailIsolationLevelTest} for testing the {@link SchemaCachingRDFSInferencer}.
+ */
+public class SchemaCachingRDFSInferencerIsolationLevelTest extends SailIsolationLevelTest {
+
+	/*---------*
+	 * Methods *
+	 *---------*/
+
+	@Override
+	protected Sail createSail()
+		throws SailException
+	{
+		// TODO we are testing the inferencer, not the store. We should use a mock here instead of a real memory store.
+		return new SchemaCachingRDFSInferencer(new MemoryStore());
+	}
+}

--- a/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencer.java
+++ b/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencer.java
@@ -44,7 +44,7 @@ import org.eclipse.rdf4j.sail.inferencer.InferencerConnection;
  * </p>
  * <p>
  * This reasoner is not a rule based reasoner and will be up to 80x faster than the
- * ForwardChainingRDFSInferencer, as well as being more complete.
+ * {@link ForwardChainingRDFSInferencer}, as well as being more complete.
  * </p>
  * <p>
  * The sail puts no limitations on isolation level for read transactions, however all write/delete/update
@@ -100,6 +100,14 @@ public class SchemaCachingRDFSInferencer extends NotifyingSailWrapper {
 	// THIS BEHAVIOUR WILL BE SWITCHED ON THE NEXT MAJOR RELEASE
 	private boolean addInferredStatementsToDefaultContext = true;
 
+	/**
+	 * Instantiate a new SchemaCachingRDFSInferencer
+	 */
+	public SchemaCachingRDFSInferencer() {
+	    super();
+	    schema = null;
+	}
+	
 	/**
 	 * Instantiate a SchemaCachingRDFSInferencer.
 	 *

--- a/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerConnection.java
+++ b/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/SchemaCachingRDFSInferencerConnection.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailConnectionListener;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.UnknownSailTransactionStateException;
+import org.eclipse.rdf4j.sail.UpdateContext;
 import org.eclipse.rdf4j.sail.inferencer.InferencerConnection;
 import org.eclipse.rdf4j.sail.inferencer.InferencerConnectionWrapper;
 import org.slf4j.Logger;
@@ -810,4 +811,9 @@ public class SchemaCachingRDFSInferencerConnection extends InferencerConnectionW
 		statementsRemoved = true;
 	}
 
+	@Override
+	public void addStatement(UpdateContext modify, Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
+		addStatement(false, subj, pred, obj, contexts);
+		super.addStatement(modify, subj, pred, obj, contexts);
+	}
 }

--- a/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/SchemaCachingRDFSInferencerConfig.java
+++ b/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/SchemaCachingRDFSInferencerConfig.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.inferencer.fc.config;
+
+import org.eclipse.rdf4j.sail.config.AbstractDelegatingSailImplConfig;
+import org.eclipse.rdf4j.sail.config.SailImplConfig;
+import org.eclipse.rdf4j.sail.inferencer.fc.SchemaCachingRDFSInferencer;
+
+/**
+ * {@link SailImplConfig} for the {@link SchemaCachingRDFSInferencer}
+ * 
+ * @author Jeen Broekstra
+ */
+public class SchemaCachingRDFSInferencerConfig extends AbstractDelegatingSailImplConfig {
+
+	public SchemaCachingRDFSInferencerConfig() {
+		super(SchemaCachingRDFSInferencerFactory.SAIL_TYPE);
+	}
+
+	public SchemaCachingRDFSInferencerConfig(SailImplConfig delegate) {
+		super(SchemaCachingRDFSInferencerFactory.SAIL_TYPE, delegate);
+	}
+}

--- a/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/SchemaCachingRDFSInferencerFactory.java
+++ b/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/SchemaCachingRDFSInferencerFactory.java
@@ -38,7 +38,7 @@ public class SchemaCachingRDFSInferencerFactory implements SailFactory {
 
 	@Override
 	public SailImplConfig getConfig() {
-		return new ForwardChainingRDFSInferencerConfig();
+		return new SchemaCachingRDFSInferencerConfig();
 	}
 
 	@Override

--- a/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/SchemaCachingRDFSInferencerFactory.java
+++ b/inferencer/src/main/java/org/eclipse/rdf4j/sail/inferencer/fc/config/SchemaCachingRDFSInferencerFactory.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.inferencer.fc.config;
+
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.config.SailConfigException;
+import org.eclipse.rdf4j.sail.config.SailFactory;
+import org.eclipse.rdf4j.sail.config.SailImplConfig;
+import org.eclipse.rdf4j.sail.inferencer.fc.ForwardChainingRDFSInferencer;
+import org.eclipse.rdf4j.sail.inferencer.fc.SchemaCachingRDFSInferencer;
+
+/**
+ * A {@link SailFactory} that creates {@link SchemaCachingRDFSInferencer}s based on RDF configuration data.
+ * 
+ * @author Jeen Broekstra
+ */
+public class SchemaCachingRDFSInferencerFactory implements SailFactory {
+
+	/**
+	 * The type of repositories that are created by this factory.
+	 * 
+	 * @see SailFactory#getSailType()
+	 */
+	public static final String SAIL_TYPE = "rdf4j:SchemaCachingRDFSInferencer";
+
+	/**
+	 * Returns the Sail's type: <tt>rdf4j:SchemaCachingRDFSInferencer</tt>.
+	 */
+	@Override
+	public String getSailType() {
+		return SAIL_TYPE;
+	}
+
+	@Override
+	public SailImplConfig getConfig() {
+		return new ForwardChainingRDFSInferencerConfig();
+	}
+
+	@Override
+	public Sail getSail(SailImplConfig config)
+		throws SailConfigException
+	{
+		if (!SAIL_TYPE.equals(config.getType())) {
+			throw new SailConfigException("Invalid Sail type: " + config.getType());
+		}
+
+		return new SchemaCachingRDFSInferencer();
+	}
+}

--- a/inferencer/src/main/resources/META-INF/services/org.eclipse.rdf4j.sail.config.SailFactory
+++ b/inferencer/src/main/resources/META-INF/services/org.eclipse.rdf4j.sail.config.SailFactory
@@ -1,3 +1,4 @@
+org.eclipse.rdf4j.sail.inferencer.fc.config.SchemaCachingRDFSInferencerFactory
 org.eclipse.rdf4j.sail.inferencer.fc.config.ForwardChainingRDFSInferencerFactory
 org.eclipse.rdf4j.sail.inferencer.fc.config.DirectTypeHierarchyInferencerFactory
 org.eclipse.rdf4j.sail.inferencer.fc.config.CustomGraphQueryInferencerFactory


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1226 .

Briefly describe the changes proposed in this PR:

* added SPI config/factory for SchemaCachingInferencer sail stack instantiation
* minor bugfix by @hmottestad  in SchemaCachingInferencer handling of SPARQL updates
* added tests 
