### PR TITLE
eclipse/rdf4j#552 rename Sail.initialize() to init(), replace usage, clean up tests

### DIFF
--- a/compliance/store/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
@@ -26,7 +26,7 @@ public class MemoryStoreTest extends RDFNotifyingStoreTest {
 		throws SailException
 	{
 		NotifyingSail sail = new MemoryStore();
-		sail.initialize();
+		sail.init();
 		return sail;
 	}
 }

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/sail/memory/PersistentMemoryStoreTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/sail/memory/PersistentMemoryStoreTest.java
@@ -8,13 +8,13 @@
 
 package org.eclipse.rdf4j.sail.memory;
 
-import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.rdf4j.common.io.FileUtil;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.RDFNotifyingStoreTest;
 import org.eclipse.rdf4j.sail.SailException;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 /**
  * An extension of RDFStoreTest for testing the class
@@ -22,16 +22,16 @@ import org.eclipse.rdf4j.sail.SailException;
  */
 public class PersistentMemoryStoreTest extends RDFNotifyingStoreTest {
 
-	private volatile File dataDir;
+	@Rule
+	public TemporaryFolder tempDir = new TemporaryFolder();
 
 	@Override
 	protected NotifyingSail createSail()
 		throws SailException
 	{
 		try {
-			dataDir = FileUtil.createTempDir(PersistentMemoryStoreTest.class.getSimpleName());
-			NotifyingSail sail = new MemoryStore(dataDir);
-			sail.initialize();
+			NotifyingSail sail = new MemoryStore(tempDir.newFolder(PersistentMemoryStoreTest.class.getSimpleName()));
+			sail.init();
 			return sail;
 		}
 		catch (IOException e) {
@@ -39,15 +39,4 @@ public class PersistentMemoryStoreTest extends RDFNotifyingStoreTest {
 		}
 	}
 
-	@Override
-	public void tearDown()
-		throws Exception
-	{
-		try {
-			super.tearDown();
-		}
-		finally {
-			FileUtil.deleteDir(dataDir);
-		}
-	}
 }

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreContextTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreContextTest.java
@@ -37,7 +37,7 @@ public class NativeStoreContextTest extends RDFNotifyingStoreTest {
 	{
 		try {
 			NotifyingSail sail = new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc");
-			sail.initialize();
+			sail.init();
 			return sail;
 		}
 		catch (IOException e) {

--- a/compliance/store/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTest.java
@@ -41,7 +41,7 @@ public class NativeStoreTest extends RDFNotifyingStoreTest {
 	{
 		try {
 			NotifyingSail sail = new NativeStore(tempDir.newFolder("nativestore"), "spoc,posc");
-			sail.initialize();
+			sail.init();
 			return sail;
 		}
 		catch (IOException e) {
@@ -61,7 +61,7 @@ public class NativeStoreTest extends RDFNotifyingStoreTest {
 
 		con.close();
 		sail.shutDown();
-		sail.initialize();
+		sail.init();
 		con = sail.getConnection();
 
 		assertEquals(RDF.NAMESPACE, con.getNamespace("rdf"));

--- a/federation/src/main/java/org/eclipse/rdf4j/sail/federation/Federation.java
+++ b/federation/src/main/java/org/eclipse/rdf4j/sail/federation/Federation.java
@@ -254,20 +254,28 @@ public class Federation implements Sail, Executor, FederatedServiceResolverClien
 		}
 	}
 
-	@Override
+	@Deprecated
 	public void initialize()
+		throws SailException
+	{
+		init();
+	}
+
+
+	@Override
+	public void init()
 		throws SailException
 	{
 		for (Repository member : members) {
 			try {
-				member.initialize();
+				member.init();
 			}
 			catch (RepositoryException e) {
 				throw new SailException(e);
 			}
 		}
 	}
-
+	
 	@Override
 	public void shutDown()
 		throws SailException

--- a/repository-sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepository.java
+++ b/repository-sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepository.java
@@ -150,7 +150,7 @@ public class SailRepository extends AbstractRepository implements FederatedServi
 		throws RepositoryException
 	{
 		try {
-			sail.initialize();
+			sail.init();
 		}
 		catch (SailLockedException e) {
 			String l = e.getLockedBy();

--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/Sail.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/Sail.java
@@ -48,9 +48,27 @@ public interface Sail {
 	 *         If the Sail could not be initialized.
 	 * @throws IllegalStateException
 	 *         If the Sail has already been initialized.
+	 * @deprecated Use {{@link #init()} instead.
 	 */
+	@Deprecated
 	void initialize()
 		throws SailException;
+	
+	/**
+	 * Initializes the Sail. Care should be taken that required initialization parameters have been set before
+	 * this method is called. Please consult the specific Sail implementation for information about the
+	 * relevant parameters.
+	 * 
+	 * @throws SailException
+	 *         If the Sail could not be initialized.
+	 * @throws IllegalStateException
+	 *         If the Sail has already been initialized.
+	 *         
+	 * @since 2.5
+	 */
+	default void init() throws SailException {
+		initialize();
+	}
 
 	/**
 	 * Shuts down the Sail, giving it the opportunity to synchronize any stale data. Care should be taken that

--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
@@ -173,8 +173,15 @@ public abstract class AbstractSail implements Sail {
 		return initialized;
 	}
 
+	
 	@Override
-	public void initialize()
+	public void initialize() throws SailException 
+	{
+		init();
+	}
+	
+	@Override
+	public void init()
 		throws SailException
 	{
 		initializationLock.writeLock().lock();


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#552 .

Briefly describe the changes proposed in this PR:

* deprecated `Sail.initialize()` and introduce preferred alt `Sail.init()`
* test cleanup
