### PR TITLE
eclipse/rdf4j#1182 use logger instead of println

### DIFF
--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  */
 public class ShaclSailConnection extends NotifyingSailConnectionWrapper {
 
-	private final Logger logger = LoggerFactory.getLogger(getClass());
+	private static final Logger logger = LoggerFactory.getLogger(ShaclSailConnection.class);
 
 	private NotifyingSailConnection previousStateConnection;
 	private Repository addedStatements;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/FilterPlanNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/FilterPlanNode.java
@@ -10,8 +10,11 @@ package org.eclipse.rdf4j.sail.shacl.planNodes;
 
 
 import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,6 +24,9 @@ import java.util.List;
  * @author Håvard Ottestad
  */
 public abstract class FilterPlanNode<T extends PushBasedPlanNode & SupportsParentProvider> implements ParentProvider {
+
+	static private final Logger logger = LoggerFactory.getLogger(FilterPlanNode.class);
+
 
 	PlanNode parent;
 
@@ -84,7 +90,7 @@ public abstract class FilterPlanNode<T extends PushBasedPlanNode & SupportsParen
 					} else {
 						if (falseNode != null) {
 							if(LoggingNode.loggingEnabled){
-								System.out.println(leadingSpace() + that.getClass().getSimpleName() + ";falseNode: " + " " + temp.toString());
+								logger.debug(leadingSpace() + that.getClass().getSimpleName() + ";falseNode: " + " " + temp.toString());
 							}
 							falseNode.push(temp);
 
@@ -177,11 +183,6 @@ public abstract class FilterPlanNode<T extends PushBasedPlanNode & SupportsParen
 
 
 	private String leadingSpace() {
-		StringBuilder ret = new StringBuilder();
-		int depth = parent.depth()+1;
-		while (--depth > 0) {
-			ret.append("    ");
-		}
-		return ret.toString();
+		return StringUtils.leftPad("", parent.depth(), "    ");
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LoggingNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LoggingNode.java
@@ -8,9 +8,12 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.sail.SailException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.List;
@@ -21,6 +24,9 @@ import java.util.stream.Stream;
  * @author Håvard Ottestad
  */
 public class LoggingNode implements PlanNode {
+
+	static private final Logger logger = LoggerFactory.getLogger(LoggingNode.class);
+
 
 	PlanNode parent;
 
@@ -93,7 +99,7 @@ public class LoggingNode implements PlanNode {
 				public boolean hasNext() throws SailException {
 					boolean hasNext = parentIterator.hasNext();
 
-					//System.out.println(leadingSpace()+parent.getClass().getSimpleName()+".hasNext() : "+hasNext);
+//					logger.debug(leadingSpace()+parent.getClass().getSimpleName()+".hasNext() : "+hasNext);
 					return hasNext;
 				}
 
@@ -105,7 +111,7 @@ public class LoggingNode implements PlanNode {
 
 					assert next != null;
 
-					System.out.println(leadingSpace() + parent.getClass().getSimpleName() + ".next(): " + " " + next.toString());
+					logger.debug(leadingSpace() + parent.getClass().getSimpleName() + ".next(): " + " " + next.toString());
 
 					return next;
 				}
@@ -140,11 +146,7 @@ public class LoggingNode implements PlanNode {
 	}
 
 	private String leadingSpace() {
-		StringBuilder ret = new StringBuilder();
-		int depth = depth();
-		while (--depth > 0) {
-			ret.append("    ");
-		}
-		return ret.toString();
+		return StringUtils.leftPad("", depth(), "    ");
 	}
+
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/PushBasedLoggingNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/PushBasedLoggingNode.java
@@ -1,11 +1,17 @@
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class PushBasedLoggingNode implements SupportsParentProvider, PushBasedPlanNode, PlanNode {
+
+	static private final Logger logger = LoggerFactory.getLogger(PushBasedLoggingNode.class);
+
 
 	private final PushBasedPlanNode parent;
 	private List<PlanNode> parents;
@@ -43,7 +49,7 @@ public class PushBasedLoggingNode implements SupportsParentProvider, PushBasedPl
 	@Override
 	public void push(Tuple t) {
 		if(LoggingNode.loggingEnabled){
-			System.out.println(leadingSpace() + parent.getClass().getSimpleName() + ".next(): " + " " + t.toString());
+			logger.debug(leadingSpace() + parent.getClass().getSimpleName() + ".next(): " + " " + t.toString());
 		}
 		parent.push(t);
 	}
@@ -61,11 +67,6 @@ public class PushBasedLoggingNode implements SupportsParentProvider, PushBasedPl
 	}
 
 	private String leadingSpace() {
-		StringBuilder ret = new StringBuilder();
-		int depth = depth();
-		while (--depth > 0) {
-			ret.append("    ");
-		}
-		return ret.toString();
+		return StringUtils.leftPad("", depth(), "    ");
 	}
 }

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
@@ -130,7 +130,7 @@ public class ShaclTest {
 
 
 
-	void runTestCase(String shaclPath, String dataPath, ExpectedResult expectedResult) {
+	private void runTestCase(String shaclPath, String dataPath, ExpectedResult expectedResult) {
 
 		if (!dataPath.endsWith("/")) {
 			dataPath = dataPath + "/";

--- a/shacl/src/test/resources/logback-test.xml
+++ b/shacl/src/test/resources/logback-test.xml
@@ -11,5 +11,10 @@
 		<level value="info" />
 		<appender-ref ref="STDOUT" />
 	</root>
+
+	<logger name="org.eclipse.rdf4j.sail.shacl" level="debug"/>
+
+
+
 </configuration>
 


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1182 .

Briefly describe the changes proposed in this PR:

* use logger instead of println when logging execution og shacl validation 