### PR TITLE
eclipse/rdf4j#1113 added config and factory class for ShaclSail

### DIFF
--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -96,6 +96,10 @@ public class ShaclSail extends NotifyingSailWrapper {
 		shapesRepo.initialize();
 	}
 
+	public ShaclSail() {
+		super();
+	}
+
 	@Override
 	public void initialize() throws SailException {
 		super.initialize();

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfig.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.shacl.config;
+
+import org.eclipse.rdf4j.sail.config.AbstractDelegatingSailImplConfig;
+import org.eclipse.rdf4j.sail.config.SailImplConfig;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+
+
+/**
+ * A {@link SailImplConfig} for {@link ShaclSail}. 
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class ShaclSailConfig extends AbstractDelegatingSailImplConfig {
+
+	public ShaclSailConfig() {
+		super(ShaclSailFactory.SAIL_TYPE);
+	}
+}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailFactory.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailFactory.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.shacl.config;
+
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.config.SailConfigException;
+import org.eclipse.rdf4j.sail.config.SailFactory;
+import org.eclipse.rdf4j.sail.config.SailImplConfig;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+
+/**
+ * Factory class for creation of {@link ShaclSail}s as part of a Sail stack.
+ * 
+ * @author Jeen Broekstra
+ */
+public class ShaclSailFactory implements SailFactory {
+
+	/**
+	 * The type of Sails that are created by this factory.
+	 * 
+	 * @see SailFactory#getSailType()
+	 */
+	public static final String SAIL_TYPE = "rdf4j:ShaclSail";
+
+	@Override
+	public String getSailType() {
+		return SAIL_TYPE;
+	}
+
+	@Override
+	public SailImplConfig getConfig() {
+		return new ShaclSailConfig();
+	}
+
+	@Override
+	public Sail getSail(SailImplConfig config) throws SailConfigException {
+		if (!SAIL_TYPE.equals(config.getType())) {
+			throw new SailConfigException("Invalid Sail type: " + config.getType());
+		}
+
+		return new ShaclSail();
+	}
+
+}


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1113 .

Briefly describe the changes proposed in this PR:

* added simple config and factory class for ShaclSail: this will enable use of ShaclSail as part of 
sail stack config in RDF4J Server, Console, and other tools. 
