### PR TITLE
eclipse/rdf4j#1269 support for implicit target class by enriching shapes through sparql query

### DIFF
--- a/compliance/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SHACLComplianceTest.java
+++ b/compliance/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/SHACLComplianceTest.java
@@ -24,18 +24,20 @@ import junit.framework.TestSuite;
  */
 public class SHACLComplianceTest extends AbstractSHACLTest {
 
+	// set this to true to run all tests!
+	final static boolean RUN_ALL = false;
+
 	public static TestSuite suite()
 		throws Exception
 	{
+		String[] ignoredDirectories = {"targets", "sparql", "complex", "misc", "node", "path", "validation-reports", "property"};
+		if(RUN_ALL) ignoredDirectories = new String[0];
+
 		return new SHACLManifestTestSuiteFactory().createTestSuite(new TestFactory() {
 
 			@Override
 			public AbstractSHACLTest createSHACLTest(String testURI, String label, Model shapesGraph,
-					Model dataGraph, boolean failure, boolean conforms)
-			{
-				if (label.contains("multiple") || label.contains("implicit")
-						|| label.contains("targetObjects"))
-					return null; // skip
+													 Model dataGraph, boolean failure, boolean conforms) {
 				return new SHACLComplianceTest(testURI, label, shapesGraph, dataGraph, failure, conforms);
 			}
 
@@ -44,7 +46,7 @@ public class SHACLComplianceTest extends AbstractSHACLTest {
 				return SHACLComplianceTest.class.getName();
 			}
 
-		}, true, true, false, "targets", "sparql", "complex", "misc", "node", "path", "validation-reports", "property");
+		}, true, true, false, ignoredDirectories);
 	}
 
 	public SHACLComplianceTest(String testURI, String label, Model shapesGraph, Model dataGraph,

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -147,6 +147,8 @@ public class ShaclSail extends NotifyingSailWrapper {
 	private static String SH_OR_UPDATE_QUERY;
 
 	private static String SH_OR_NODE_SHAPE_UPDATE_QUERY;
+	private static String IMPLICIT_TARGET_CLASS_NODE_SHAPE;
+	private static String IMPLICIT_TARGET_CLASS_PROPERTY_SHAPE;
 
 	/**
 	 * an initialized {@link Repository} for storing/retrieving Shapes data
@@ -161,6 +163,13 @@ public class ShaclSail extends NotifyingSailWrapper {
 			SH_OR_NODE_SHAPE_UPDATE_QUERY = IOUtils.toString(
 					ShaclSail.class.getClassLoader().getResourceAsStream("shacl-sparql-inference/sh_or_node_shape.rq"),
 					"UTF-8");
+			IMPLICIT_TARGET_CLASS_NODE_SHAPE = IOUtils.toString(
+				ShaclSail.class.getClassLoader().getResourceAsStream("shacl-sparql-inference/implicitTargetClassNodeShape.rq"),
+				"UTF-8");
+
+			IMPLICIT_TARGET_CLASS_PROPERTY_SHAPE = IOUtils.toString(
+				ShaclSail.class.getClassLoader().getResourceAsStream("shacl-sparql-inference/implicitTargetClassPropertyShape.rq"),
+				"UTF-8");
 		}
 		catch (IOException e) {
 			throw new IllegalStateException(e);
@@ -311,6 +320,8 @@ public class ShaclSail extends NotifyingSailWrapper {
 			prevSize = currentSize;
 			shaclSailConnection.prepareUpdate(SH_OR_NODE_SHAPE_UPDATE_QUERY).execute();
 			shaclSailConnection.prepareUpdate(SH_OR_UPDATE_QUERY).execute();
+			shaclSailConnection.prepareUpdate(IMPLICIT_TARGET_CLASS_PROPERTY_SHAPE).execute();
+			shaclSailConnection.prepareUpdate(IMPLICIT_TARGET_CLASS_NODE_SHAPE).execute();
 			currentSize = shaclSailConnection.size();
 		}
 		while (prevSize != currentSize);

--- a/shacl/src/main/resources/shacl-sparql-inference/implicitTargetClassNodeShape.rq
+++ b/shacl/src/main/resources/shacl-sparql-inference/implicitTargetClassNodeShape.rq
@@ -1,0 +1,18 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+
+insert {
+
+        ?a sh:targetClass ?a ;
+
+} where {
+
+        ?a
+                rdf:type rdfs:Class ;
+                rdf:type sh:NodeShape ;
+        .
+}

--- a/shacl/src/main/resources/shacl-sparql-inference/implicitTargetClassPropertyShape.rq
+++ b/shacl/src/main/resources/shacl-sparql-inference/implicitTargetClassPropertyShape.rq
@@ -1,0 +1,18 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+
+insert {
+
+        ?a sh:targetClass ?a ;
+        
+} where {
+
+        ?a
+                rdf:type rdfs:Class ;
+                rdf:type sh:PropertyShape ;
+        .
+}

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -57,7 +57,8 @@ abstract public class AbstractShaclTest {
 		"test-cases/or/minCount",
 		"test-cases/or/nodeKindMinLength",
 		"test-cases/or/implicitAnd",
-		"test-cases/or/datatypeDifferentPaths"
+		"test-cases/or/datatypeDifferentPaths",
+		"test-cases/implicitTargetClass/simple"
 
 	);
 

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case1/query1.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case1/query1.rq
@@ -1,0 +1,13 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 a ex:Person ;
+	ex:age "123".
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case2/query1.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case2/query1.rq
@@ -1,0 +1,13 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 a ex:Person ;
+	ex:age 123.
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case2/query2.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case2/query2.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 ex:age "123".
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case3/query1.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case3/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 ex:age "123".
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case3/query2.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case3/query2.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 a ex:Person .
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case4/query1.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case4/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 ex:age "123".
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case4/query2.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case4/query2.rq
@@ -1,0 +1,14 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1
+        ex:age 234 ;
+        a ex:Person .
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case5/query1.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case5/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 ex:age "123".
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case5/query2.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/invalid/case5/query2.rq
@@ -1,0 +1,18 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1
+        ex:age 234 ;
+        a ex:Person .
+
+ex:validPerson2
+        ex:age 234 ;
+        a ex:Person .
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/shacl.ttl
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/shacl.ttl
@@ -1,0 +1,15 @@
+@base <http://example.com/ns> .
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ex:Person
+	a rdfs:Class, sh:NodeShape  ;
+	sh:property [
+		sh:path ex:age ;
+		sh:datatype xsd:integer ;
+	] .
+

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case1/query1.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case1/query1.rq
@@ -1,0 +1,13 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 a ex:Person ;
+	ex:age 123.
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case2/query1.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case2/query1.rq
@@ -1,0 +1,13 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 a ex:Person ;
+	ex:age 123.
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case2/query2.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case2/query2.rq
@@ -1,0 +1,13 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 ex:age 234.
+
+}
+

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case3/query1.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case3/query1.rq
@@ -1,0 +1,12 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+ex:validPerson1 ex:age "123".
+
+}

--- a/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case3/query2.rq
+++ b/shacl/src/test/resources/test-cases/implicitTargetClass/simple/valid/case3/query2.rq
@@ -1,0 +1,15 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+
+
+ex:validPerson2
+        ex:age 234 ;
+        a ex:Person .
+
+}


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1269 .

Briefly describe the changes proposed in this PR:

* use SPARQL to enrich shapes graph with sh:targetClass if shape is NodeShape or PropertyShape and rdfs:Class