### PR TITLE
Fix for returning milliseconds in SPARQL SECONDS()

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/Seconds.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/datetime/Seconds.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.function.datetime;
 
+import java.math.BigDecimal;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -51,7 +52,11 @@ public class Seconds implements Function {
 
 					int seconds = calValue.getSecond();
 					if (DatatypeConstants.FIELD_UNDEFINED != seconds) {
-						return valueFactory.createLiteral(String.valueOf(seconds), XMLSchema.DECIMAL);
+						BigDecimal fraction = calValue.getFractionalSecond();
+						String str = (fraction == null) ? String.valueOf(seconds) 
+														: String.valueOf(fraction.doubleValue() + seconds);
+
+						return valueFactory.createLiteral(str, XMLSchema.DECIMAL);
 					}
 					else {
 						throw new ValueExprEvaluationException(


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1267 .

Briefly describe the changes proposed in this PR:

* Return milliseconds (and even more detailed fractions of a second) if set
