### PR TITLE
Issues/1278 shacl isolation levels

### DIFF
--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -136,8 +136,8 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			if(!preparedHasRun) {
 				prepare();
 			}
-			super.commit();
 			previousStateConnection.commit();
+			super.commit();
 			shapesConnection.commit();
 			cleanup();
 
@@ -198,7 +198,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 	@Override
 	public void rollback() throws SailException {
 		synchronized (sail) {
-			previousStateConnection.commit();
+			previousStateConnection.rollback();
 			shapesConnection.rollback();
 			super.rollback();
 			cleanup();

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
@@ -20,7 +20,6 @@ import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
-import org.eclipse.rdf4j.query.algebra.QueryModelVisitor;
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor;
 import org.eclipse.rdf4j.query.impl.ListBindingSet;
 import org.eclipse.rdf4j.query.impl.MapBindingSet;
@@ -41,10 +40,10 @@ import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad
- *
+ * <p>
  * This inner join algorithm assumes the left iterator is unique for tuple[0], eg. no two tuples have the same value at index 0.
  * The right iterator is allowed to contain duplicates.
- *
+ * <p>
  * External means that this plan node can join the iterator from a plan node with an external
  * source (Repository or NotifyingSailConnection) based on a query or a predicate.
  */
@@ -113,7 +112,6 @@ public class BulkedExternalInnerJoin implements PlanNode {
 				}
 
 
-
 				if (!left.isEmpty()) {
 					return;
 				}
@@ -129,7 +127,6 @@ public class BulkedExternalInnerJoin implements PlanNode {
 				}
 
 				if (query != null) {
-
 
 
 					if (repository != null) {
@@ -154,7 +151,7 @@ public class BulkedExternalInnerJoin implements PlanNode {
 //						parsedQuery = queryParserFactory.getParser().parseQuery("select * where { VALUES (?a) {}" + query + "} order by ?a", null);
 
 						try {
-							parsedQuery.getTupleExpr().visitChildren(new AbstractQueryModelVisitor<Exception>(){
+							parsedQuery.getTupleExpr().visitChildren(new AbstractQueryModelVisitor<Exception>() {
 								@Override
 								public void meet(BindingSetAssignment node) throws Exception {
 
@@ -213,11 +210,13 @@ public class BulkedExternalInnerJoin implements PlanNode {
 			public Tuple next() throws SailException {
 				calculateNext();
 
-				if (!left.isEmpty()) {
+
+				Tuple joined = null;
+
+				while (joined == null) {
 
 					Tuple leftPeek = left.peekLast();
 
-					Tuple joined = null;
 
 					if (!right.isEmpty()) {
 						Tuple rightPeek = right.peekLast();
@@ -234,22 +233,33 @@ public class BulkedExternalInnerJoin implements PlanNode {
 
 								left.removeLast();
 							}
+						} else {
+							int compare = rightPeek.line.get(0).stringValue().compareTo(leftPeek.line.get(0).stringValue());
 
+							if (compare < 0) {
+								if (right.isEmpty()) {
+									throw new IllegalStateException();
+								}
 
+								right.removeLast();
+								System.out.println();
+
+							} else {
+								if (left.isEmpty()) {
+									throw new IllegalStateException();
+								}
+								left.removeLast();
+								System.out.println();
+
+							}
 						}
 
 					}
-
-
-					if (joined != null) {
-						return joined;
-					}
-
-
 				}
 
+				return joined;
 
-				return null;
+
 			}
 
 			@Override
@@ -267,12 +277,12 @@ public class BulkedExternalInnerJoin implements PlanNode {
 	@Override
 	public void getPlanAsGraphvizDot(StringBuilder stringBuilder) {
 		stringBuilder.append(getId() + " [label=\"" + StringEscapeUtils.escapeJava(this.toString()) + "\"];").append("\n");
-		stringBuilder.append(leftNode.getId()+" -> "+getId()+ " [label=\"left\"]").append("\n");
-		if(repository != null){
-			stringBuilder.append( System.identityHashCode(repository)+" -> "+getId()+ " [label=\"right\"]").append("\n");
+		stringBuilder.append(leftNode.getId() + " -> " + getId() + " [label=\"left\"]").append("\n");
+		if (repository != null) {
+			stringBuilder.append(System.identityHashCode(repository) + " -> " + getId() + " [label=\"right\"]").append("\n");
 		}
-		if(baseSailConnection != null){
-			stringBuilder.append( System.identityHashCode(baseSailConnection)+" -> "+getId()+ " [label=\"right\"]").append("\n");
+		if (baseSailConnection != null) {
+			stringBuilder.append(System.identityHashCode(baseSailConnection) + " -> " + getId() + " [label=\"right\"]").append("\n");
 		}
 
 		leftNode.getPlanAsGraphvizDot(stringBuilder);
@@ -288,7 +298,7 @@ public class BulkedExternalInnerJoin implements PlanNode {
 
 	@Override
 	public String getId() {
-		return System.identityHashCode(this)+"";
+		return System.identityHashCode(this) + "";
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
@@ -54,11 +54,11 @@ public class BulkedExternalInnerJoin implements PlanNode {
 
 
 	private IRI predicate;
-	NotifyingSailConnection baseSailConnection;
-	PlanNode leftNode;
-	Repository repository;
-	String query;
-	ParsedQuery parsedQuery;
+	private NotifyingSailConnection baseSailConnection;
+	private PlanNode leftNode;
+	private Repository repository;
+	private String query;
+	private ParsedQuery parsedQuery;
 
 
 	public BulkedExternalInnerJoin(PlanNode leftNode, Repository repository, String query) {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalLeftOuterJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalLeftOuterJoin.java
@@ -42,10 +42,10 @@ import java.util.stream.Stream;
 public class BulkedExternalLeftOuterJoin implements PlanNode {
 
 	private IRI predicate;
-	NotifyingSailConnection baseSailConnection;
-	PlanNode leftNode;
-	Repository repository;
-	String query;
+	private NotifyingSailConnection baseSailConnection;
+	private PlanNode leftNode;
+	private Repository repository;
+	private String query;
 
 	public BulkedExternalLeftOuterJoin(PlanNode leftNode, Repository repository, String query) {
 		this.leftNode = leftNode;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/EqualsJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/EqualsJoin.java
@@ -5,9 +5,9 @@ import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 
 public class EqualsJoin implements PlanNode{
-	PlanNode left;
-	PlanNode right;
-	boolean useAsFilter;
+	private PlanNode left;
+	private PlanNode right;
+	private boolean useAsFilter;
 
 	public EqualsJoin(PlanNode left, PlanNode right, boolean useAsFilter) {
 		this.left = left;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalTypeFilterNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalTypeFilterNode.java
@@ -23,8 +23,8 @@ import java.util.Arrays;
  */
 public class ExternalTypeFilterNode implements PlanNode {
 
-	NotifyingSailConnection shaclSailConnection;
-	Resource filterOnType;
+	private NotifyingSailConnection shaclSailConnection;
+	private Resource filterOnType;
 	PlanNode parent;
 
 	public ExternalTypeFilterNode(NotifyingSailConnection shaclSailConnection, Resource filterOnType, PlanNode parent) {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/InnerJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/InnerJoin.java
@@ -31,11 +31,11 @@ public class InnerJoin implements PlanNode, ParentProvider {
 	static private final Logger logger = LoggerFactory.getLogger(InnerJoin.class);
 
 
-	PlanNode left;
-	PlanNode right;
+	private PlanNode left;
+	private PlanNode right;
 
-	PushBasedPlanNode discardedLeft;
-	PushBasedPlanNode discardedRight;
+	private PushBasedPlanNode discardedLeft;
+	private PushBasedPlanNode discardedRight;
 
 	public InnerJoin(PlanNode left, PlanNode right, PushBasedPlanNode discardedLeft, PushBasedPlanNode discardedRight) {
 		this.left = left;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LeftOuterJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LeftOuterJoin.java
@@ -19,8 +19,8 @@ import org.eclipse.rdf4j.sail.SailException;
  */
 public class LeftOuterJoin implements PlanNode {
 
-	PlanNode left;
-	PlanNode right;
+	private PlanNode left;
+	private PlanNode right;
 
 	public LeftOuterJoin(PlanNode left, PlanNode right) {
 		this.left = left;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LoggingNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LoggingNode.java
@@ -27,7 +27,6 @@ public class LoggingNode implements PlanNode {
 
 	static private final Logger logger = LoggerFactory.getLogger(LoggingNode.class);
 
-
 	PlanNode parent;
 
 	private boolean pullAll = true;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Select.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Select.java
@@ -30,10 +30,10 @@ import java.util.Objects;
  */
 public class Select implements PlanNode {
 
-	final Repository repository;
-	ShaclSailConnection connection;
+	private final Repository repository;
+	private ShaclSailConnection connection;
 
-	String query;
+	private String query;
 
 	public Select(Repository repository, String query) {
 		this.repository = repository;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/TrimTuple.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/TrimTuple.java
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.sail.SailException;
 public class TrimTuple implements PlanNode {
 
 	PlanNode parent;
-	int newLength;
+	private int newLength;
 
 	public TrimTuple(PlanNode parent, int newLength) {
 		this.parent = parent;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnionNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnionNode.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
  */
 public class UnionNode implements PlanNode {
 
-	PlanNode[] nodes;
+	private PlanNode[] nodes;
 
 
 	public UnionNode(PlanNode... nodes) {

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/BulkedExternalInnerJoinTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/BulkedExternalInnerJoinTest.java
@@ -1,0 +1,63 @@
+package org.eclipse.rdf4j.sail.shacl;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCAT;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.shacl.mock.MockConsumePlanNode;
+import org.eclipse.rdf4j.sail.shacl.mock.MockInputPlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.BulkedExternalInnerJoin;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.Tuple;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class BulkedExternalInnerJoinTest {
+
+	@Test
+	public void gapInResultsFromQueryTest(){
+
+		SimpleValueFactory vf = SimpleValueFactory.getInstance();
+		IRI a = vf.createIRI("http://a");
+		IRI b = vf.createIRI("http://b");
+		IRI c = vf.createIRI("http://c");
+		IRI d = vf.createIRI("http://d");
+
+
+		PlanNode left = new MockInputPlanNode(Arrays.asList(
+			new Tuple(Collections.singletonList(a)),
+			new Tuple(Collections.singletonList(b)),
+			new Tuple(Collections.singletonList(c)),
+			new Tuple(Collections.singletonList(d))
+		));
+
+		SailRepository sailRepository = new SailRepository(new MemoryStore());
+		sailRepository.init();
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+			connection.add(b, DCAT.ACCESS_URL,RDFS.RESOURCE);
+			connection.add(d, DCAT.ACCESS_URL,RDFS.SUBPROPERTYOF);
+		}
+
+		BulkedExternalInnerJoin bulkedExternalInnerJoin = new BulkedExternalInnerJoin(left, sailRepository, "?a <http://www.w3.org/ns/dcat#accessURL> ?c. ");
+
+		List<Tuple> tuples = new MockConsumePlanNode(bulkedExternalInnerJoin).asList();
+
+		tuples.forEach(System.out::println);
+
+		assertEquals("[http://b, http://www.w3.org/2000/01/rdf-schema#Resource]", Arrays.toString(tuples.get(0).line.toArray()));
+		assertEquals("[http://d, http://www.w3.org/2000/01/rdf-schema#subPropertyOf]", Arrays.toString(tuples.get(1).line.toArray()));
+
+
+	}
+
+}

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclSailSupportedPredicatesDocumentationTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclSailSupportedPredicatesDocumentationTest.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl;
 
+import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
@@ -35,10 +36,9 @@ public class ShaclSailSupportedPredicatesDocumentationTest extends AbstractShacl
 
 	private static HashSet<IRI> staticShaclPredicates = new HashSet<>(ShaclSail.getSupportedShaclPredicates());
 
-	public ShaclSailSupportedPredicatesDocumentationTest(String testCasePath, String path, ExpectedResult expectedResult) {
-		super(testCasePath, path, expectedResult);
+	public ShaclSailSupportedPredicatesDocumentationTest(String testCasePath, String path, ExpectedResult expectedResult, IsolationLevel isolationLevel) {
+		super(testCasePath, path, expectedResult, isolationLevel);
 	}
-
 
 	@AfterClass
 	public static void afterClass() {

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl;
 
+import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.model.IRI;
@@ -47,19 +48,18 @@ import static org.junit.Assert.assertFalse;
 public class ShaclTest extends AbstractShaclTest{
 
 
-	public ShaclTest(String testCasePath, String path, AbstractShaclTest.ExpectedResult expectedResult) {
-		super(testCasePath, path, expectedResult);
+	public ShaclTest(String testCasePath, String path, ExpectedResult expectedResult, IsolationLevel isolationLevel) {
+		super(testCasePath, path, expectedResult, isolationLevel);
 	}
-
 
 	@Test
 	public void test() throws Exception {
-		runTestCase(testCasePath, path, expectedResult);
+		runTestCase(testCasePath, path, expectedResult, isolationLevel);
 	}
 
 	@Test
 	public void testSingleTransaction() throws Exception {
-		runTestCaseSingleTransaction(testCasePath, path, expectedResult);
+		runTestCaseSingleTransaction(testCasePath, path, expectedResult, isolationLevel);
 	}
 
 }


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1278 .

Briefly describe the changes proposed in this PR:

* main test suite runs in multiple isolation levels (still only takes 30 seconds)
* fixed a join problem in the BulkedExternalInnerJoin plan node (algebra node)
