### PR TITLE
Always use UTF8 to get raw bytes of a string

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/HashFunction.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/hash/HashFunction.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.function.hash;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -34,7 +35,7 @@ public abstract class HashFunction implements Function {
 	 */
 	protected String hash(String text, String algorithm)
 			throws NoSuchAlgorithmException {
-		byte[] hash = MessageDigest.getInstance(algorithm).digest(text.getBytes());
+		byte[] hash = MessageDigest.getInstance(algorithm).digest(text.getBytes(StandardCharsets.UTF_8));
 		BigInteger bi = new BigInteger(1, hash);
 
 		return String.format("%0" + hash.length * 2 + "x", bi);


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1284 .

Briefly describe the changes proposed in this PR:

* Get the bytes calculated on the UTF8 representation (see https://www.w3.org/TR/sparql11-query/#func-md5)
