### PR TITLE
Issues/1286 1287 optimize parsing and skip validation

### DIFF
--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
@@ -35,12 +35,10 @@ public class DatatypePropertyShape extends PathPropertyShape {
 	private final Resource datatype;
 	private static final Logger logger = LoggerFactory.getLogger(DatatypePropertyShape.class);
 
-	DatatypePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	DatatypePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Resource datatype) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.DATATYPE, null, true))) {
-			datatype = stream.map(Statement::getObject).map(v -> (Resource) v).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:datatype on " + id));
-		}
+		this.datatype = datatype;
 
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
@@ -8,24 +8,15 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.DatatypeFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
-import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
@@ -63,20 +63,6 @@ public class DatatypePropertyShape extends PathPropertyShape {
 	}
 
 	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
-
-	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.DatatypeConstraintComponent;
 	}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
@@ -10,9 +10,6 @@ package org.eclipse.rdf4j.sail.shacl.AST;
 
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -57,21 +54,6 @@ public class LanguageInPropertyShape extends PathPropertyShape {
 
 		return new EnrichWithShape(invalidValues, this);
 
-	}
-
-	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
@@ -8,12 +8,9 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -21,14 +18,12 @@ import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LanguageInFilter;
-import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad
@@ -38,14 +33,10 @@ public class LanguageInPropertyShape extends PathPropertyShape {
 	private final List<String> languageIn;
 	private static final Logger logger = LoggerFactory.getLogger(LanguageInPropertyShape.class);
 
-	LanguageInPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	LanguageInPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Resource languageIn) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.LANGUAGE_IN, null, true))) {
-			Resource orList = stream.map(Statement::getObject).map(v -> (Resource) v).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:languageIn on " + id));
-			languageIn = toList(connection, orList).stream().map(Value::stringValue).collect(Collectors.toList());
-		}
-
+		this.languageIn = toList(connection, languageIn).stream().map(Value::stringValue).collect(Collectors.toList());
 	}
 
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
@@ -80,7 +80,8 @@ public class LanguageInPropertyShape extends PathPropertyShape {
 			requiresEvalutation = true;
 		}
 
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
+		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;
+	}
 
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
@@ -13,8 +13,10 @@ import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -45,12 +47,10 @@ public class MaxCountPropertyShape extends PathPropertyShape {
 
 	private long maxCount;
 
-	MaxCountPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	MaxCountPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Long maxCount) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.MAX_COUNT, null, true))) {
-			maxCount = stream.map(Statement::getObject).map(v -> (Literal) v).map(Literal::longValue).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:maxCount on " + id));
-		}
+		this.maxCount = maxCount;
 
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
@@ -108,11 +108,6 @@ public class MaxCountPropertyShape extends PathPropertyShape {
 	}
 
 	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		return true;
-	}
-
-	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MaxCountConstraintComponent;
 	}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
@@ -9,14 +9,7 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
-import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -33,8 +26,6 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.UnionNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Stream;
 
 /**
  * The AST (Abstract Syntax Tree) node that represents a sh:maxCount property nodeShape restriction.

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
@@ -8,12 +8,9 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -26,8 +23,6 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.stream.Stream;
-
 /**
  * @author Håvard Ottestad
  */
@@ -36,12 +31,10 @@ public class MaxExclusivePropertyShape extends PathPropertyShape {
 	private final Literal maxExclusive;
 	private static final Logger logger = LoggerFactory.getLogger(MaxExclusivePropertyShape.class);
 
-	MaxExclusivePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	MaxExclusivePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Literal maxExclusive) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.MAX_EXCLUSIVE, null, true))) {
-			maxExclusive = stream.map(Statement::getObject).map(v -> ((Literal) v)).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:maxExclusive on " + id));
-		}
+		this.maxExclusive = maxExclusive;
 
 	}
 
@@ -49,7 +42,7 @@ public class MaxExclusivePropertyShape extends PathPropertyShape {
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans, boolean assumeBaseSailValid) {
 
-		PlanNode invalidValues =  StandardisedPlanHelper.getGenericSingleObjectPlan(
+		PlanNode invalidValues = StandardisedPlanHelper.getGenericSingleObjectPlan(
 			shaclSailConnection,
 			nodeShape,
 			(parent, trueNode, falseNode) -> new LiteralComparatorFilter(parent, trueNode, falseNode, maxExclusive, value -> value > 0),
@@ -77,7 +70,8 @@ public class MaxExclusivePropertyShape extends PathPropertyShape {
 			requiresEvalutation = true;
 		}
 
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
+		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;
+	}
 
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
@@ -10,9 +10,6 @@ package org.eclipse.rdf4j.sail.shacl.AST;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
@@ -59,21 +59,6 @@ public class MaxExclusivePropertyShape extends PathPropertyShape {
 	}
 
 	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;
-	}
-
-	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MaxExclusiveConstraintComponent;
 	}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxInclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxInclusivePropertyShape.java
@@ -10,9 +10,6 @@ package org.eclipse.rdf4j.sail.shacl.AST;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -56,21 +53,6 @@ public class MaxInclusivePropertyShape extends PathPropertyShape {
 
 		return new EnrichWithShape(new LoggingNode(invalidValues), this);
 
-	}
-
-	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxInclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxInclusivePropertyShape.java
@@ -8,12 +8,9 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -26,8 +23,6 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.stream.Stream;
-
 /**
  * @author Håvard Ottestad
  */
@@ -36,12 +31,10 @@ public class MaxInclusivePropertyShape extends PathPropertyShape {
 	private final Literal maxInclusive;
 	private static final Logger logger = LoggerFactory.getLogger(MaxInclusivePropertyShape.class);
 
-	MaxInclusivePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	MaxInclusivePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Literal maxInclusive) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.MAX_INCLUSIVE, null, true))) {
-			maxInclusive = stream.map(Statement::getObject).map(v -> ((Literal) v)).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:maxInclusive on " + id));
-		}
+		this.maxInclusive = maxInclusive;
 
 	}
 
@@ -49,7 +42,7 @@ public class MaxInclusivePropertyShape extends PathPropertyShape {
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans, boolean assumeBaseSailValid) {
 
-		PlanNode invalidValues =  StandardisedPlanHelper.getGenericSingleObjectPlan(
+		PlanNode invalidValues = StandardisedPlanHelper.getGenericSingleObjectPlan(
 			shaclSailConnection,
 			nodeShape,
 			(parent, trueNode, falseNode) -> new LiteralComparatorFilter(parent, trueNode, falseNode, maxInclusive, value -> value >= 0),
@@ -77,7 +70,8 @@ public class MaxInclusivePropertyShape extends PathPropertyShape {
 			requiresEvalutation = true;
 		}
 
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
+		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;
+	}
 
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
@@ -36,12 +36,10 @@ public class MaxLengthPropertyShape extends PathPropertyShape {
 	private final long maxLength;
 	private static final Logger logger = LoggerFactory.getLogger(MaxLengthPropertyShape.class);
 
-	MaxLengthPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	MaxLengthPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Long maxLength) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.MAX_LENGTH, null, true))) {
-			maxLength = stream.map(Statement::getObject).map(v -> ((SimpleLiteral) v).integerValue().longValue()).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:minLength on " + id));
-		}
+		this.maxLength = maxLength;
 
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
@@ -8,25 +8,15 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.impl.SimpleLiteral;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
-import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.MaxLengthFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad
@@ -47,7 +37,7 @@ public class MaxLengthPropertyShape extends PathPropertyShape {
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans, boolean assumeBaseSailValid) {
 
-		PlanNode invalidValues =  StandardisedPlanHelper.getGenericSingleObjectPlan(
+		PlanNode invalidValues = StandardisedPlanHelper.getGenericSingleObjectPlan(
 			shaclSailConnection,
 			nodeShape,
 			(parent, trueNode, falseNode) -> new MaxLengthFilter(parent, trueNode, falseNode, maxLength),
@@ -62,20 +52,6 @@ public class MaxLengthPropertyShape extends PathPropertyShape {
 		return new EnrichWithShape(invalidValues, this);
 
 	}
-
-	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
 
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
@@ -9,14 +9,7 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
-import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -34,8 +27,6 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.UnionNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Stream;
 
 /**
  * The AST (Abstract Syntax Tree) node that represents a sh:minCount property nodeShape restriction.

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
@@ -51,12 +51,10 @@ public class MinCountPropertyShape extends PathPropertyShape {
 	private boolean optimizeWhenNoStatementsRemoved = true;
 
 
-	MinCountPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	MinCountPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Long minCount) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.MIN_COUNT, null, true))) {
-			minCount = stream.map(Statement::getObject).map(v -> (Literal) v).map(Literal::longValue).findAny().orElseThrow(() -> new RuntimeException("Expect to find sh:minCount on " + id));
-		}
+		this.minCount = minCount;
 
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
@@ -148,22 +148,6 @@ public class MinCountPropertyShape extends PathPropertyShape {
 	}
 
 	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;
-	}
-
-	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MinCountConstraintComponent;
 	}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
@@ -8,25 +8,17 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
+import org.eclipse.rdf4j.sail.shacl.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad
@@ -47,7 +39,7 @@ public class MinExclusivePropertyShape extends PathPropertyShape {
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans, boolean assumeBaseSailValid) {
 
-		PlanNode invalidValues =  StandardisedPlanHelper.getGenericSingleObjectPlan(
+		PlanNode invalidValues = StandardisedPlanHelper.getGenericSingleObjectPlan(
 			shaclSailConnection,
 			nodeShape,
 			(parent, trueNode, falseNode) -> new LiteralComparatorFilter(parent, trueNode, falseNode, minExclusive, value -> value < 0),
@@ -62,20 +54,6 @@ public class MinExclusivePropertyShape extends PathPropertyShape {
 		return new EnrichWithShape(new LoggingNode(invalidValues), this);
 
 	}
-
-	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
 
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
@@ -36,12 +36,10 @@ public class MinExclusivePropertyShape extends PathPropertyShape {
 	private final Literal minExclusive;
 	private static final Logger logger = LoggerFactory.getLogger(MinExclusivePropertyShape.class);
 
-	MinExclusivePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	MinExclusivePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Literal minExclusive) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.MIN_EXCLUSIVE, null, true))) {
-			minExclusive = stream.map(Statement::getObject).map(v -> ((Literal) v)).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:minExclusive on " + id));
-		}
+		this.minExclusive = minExclusive;
 
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinInclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinInclusivePropertyShape.java
@@ -10,9 +10,6 @@ package org.eclipse.rdf4j.sail.shacl.AST;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
@@ -55,21 +52,6 @@ public class MinInclusivePropertyShape extends PathPropertyShape {
 
 		return new EnrichWithShape(new LoggingNode(invalidValues), this);
 
-	}
-
-	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinInclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinInclusivePropertyShape.java
@@ -8,12 +8,9 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -26,8 +23,6 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.stream.Stream;
-
 /**
  * @author Håvard Ottestad
  */
@@ -36,20 +31,17 @@ public class MinInclusivePropertyShape extends PathPropertyShape {
 	private final Literal minInclusive;
 	private static final Logger logger = LoggerFactory.getLogger(MinInclusivePropertyShape.class);
 
-	MinInclusivePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	MinInclusivePropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Literal minInclusive) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.MIN_INCLUSIVE, null, true))) {
-			minInclusive = stream.map(Statement::getObject).map(v -> ((Literal) v)).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:minInclusive on " + id));
-		}
-
+		this.minInclusive = minInclusive;
 	}
 
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans, boolean assumeBaseSailValid) {
 
-		PlanNode invalidValues =  StandardisedPlanHelper.getGenericSingleObjectPlan(
+		PlanNode invalidValues = StandardisedPlanHelper.getGenericSingleObjectPlan(
 			shaclSailConnection,
 			nodeShape,
 			(parent, trueNode, falseNode) -> new LiteralComparatorFilter(parent, trueNode, falseNode, minInclusive, value -> value <= 0),
@@ -77,7 +69,8 @@ public class MinInclusivePropertyShape extends PathPropertyShape {
 			requiresEvalutation = true;
 		}
 
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
+		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;
+	}
 
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
@@ -36,12 +36,10 @@ public class MinLengthPropertyShape extends PathPropertyShape {
 	private final long minLength;
 	private static final Logger logger = LoggerFactory.getLogger(MinLengthPropertyShape.class);
 
-	MinLengthPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	MinLengthPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Long minLength) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.MIN_LENGTH, null, true))) {
-			minLength = stream.map(Statement::getObject).map(v -> ((SimpleLiteral) v).integerValue().longValue()).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:minLength on " + id));
-		}
+		this.minLength = minLength;
 
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
@@ -8,25 +8,15 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.impl.SimpleLiteral;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
-import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.MinLengthFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad
@@ -47,7 +37,7 @@ public class MinLengthPropertyShape extends PathPropertyShape {
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans, boolean assumeBaseSailValid) {
 
-		PlanNode invalidValues =  StandardisedPlanHelper.getGenericSingleObjectPlan(
+		PlanNode invalidValues = StandardisedPlanHelper.getGenericSingleObjectPlan(
 			shaclSailConnection,
 			nodeShape,
 			(parent, trueNode, falseNode) -> new MinLengthFilter(parent, trueNode, falseNode, minLength),
@@ -62,20 +52,6 @@ public class MinLengthPropertyShape extends PathPropertyShape {
 		return new EnrichWithShape(invalidValues, this);
 
 	}
-
-	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
 
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
@@ -8,25 +8,17 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
-import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.NodeKindFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad
@@ -43,7 +35,7 @@ public class NodeKindPropertyShape extends PathPropertyShape {
 
 	}
 
-	public enum NodeKind{
+	public enum NodeKind {
 
 		BlankNode(SHACL.BLANK_NODE),
 		IRI(SHACL.IRI),
@@ -54,25 +46,27 @@ public class NodeKindPropertyShape extends PathPropertyShape {
 		;
 
 		IRI iri;
+
 		NodeKind(IRI iri) {
 			this.iri = iri;
 		}
 
-		public static NodeKind from(Resource resource){
+		public static NodeKind from(Resource resource) {
 			for (NodeKind value : NodeKind.values()) {
-				if(value.iri.equals(resource)) return value;
+				if (value.iri.equals(resource)) {
+					return value;
+				}
 			}
 
-			throw new IllegalStateException("Unknown nodeKind: "+resource);
+			throw new IllegalStateException("Unknown nodeKind: " + resource);
 		}
 	}
-
 
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans, boolean assumeBaseSailValid) {
 
-		PlanNode invalidValues =  StandardisedPlanHelper.getGenericSingleObjectPlan(
+		PlanNode invalidValues = StandardisedPlanHelper.getGenericSingleObjectPlan(
 			shaclSailConnection,
 			nodeShape,
 			(parent, trueNode, falseNode) -> new NodeKindFilter(parent, trueNode, falseNode, nodeKind),
@@ -87,20 +81,6 @@ public class NodeKindPropertyShape extends PathPropertyShape {
 		return new EnrichWithShape(invalidValues, this);
 
 	}
-
-	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
 
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
@@ -36,12 +36,10 @@ public class NodeKindPropertyShape extends PathPropertyShape {
 	private final NodeKind nodeKind;
 	private static final Logger logger = LoggerFactory.getLogger(NodeKindPropertyShape.class);
 
-	NodeKindPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	NodeKindPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Resource nodeKind) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.NODE_KIND_PROP, null, true))) {
-			nodeKind = stream.map(Statement::getObject).map(v -> (Resource) v).map(NodeKind::from).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:nodeKind on " + id));
-		}
+		this.nodeKind = NodeKind.from(nodeKind);
 
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeShape.java
@@ -74,9 +74,7 @@ public class NodeShape implements PlanGenerator, RequiresEvalutation, QueryGener
 
 	@Override
 	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		return propertyShapes
-			.stream()
-			.anyMatch(propertyShape -> propertyShape.requiresEvaluation(addedStatements, removedStatements));
+		return true;
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
@@ -134,7 +134,13 @@ public class OrPropertyShape extends PropertyShape {
 
 	@Override
 	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		return true;
+		return super.requiresEvaluation(addedStatements, removedStatements) ||
+			or
+				.stream()
+				.flatMap(Collection::stream)
+				.map(p -> p.requiresEvaluation(addedStatements, removedStatements))
+				.reduce((a, b) -> a || b)
+				.orElse(false);
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
@@ -8,10 +8,7 @@
 package org.eclipse.rdf4j.sail.shacl.AST;
 
 
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
@@ -27,9 +24,9 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad
@@ -41,16 +38,11 @@ public class OrPropertyShape extends PropertyShape {
 	private static final Logger logger = LoggerFactory.getLogger(OrPropertyShape.class);
 
 
-	OrPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	OrPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, Resource or) {
 		super(id, nodeShape);
+		this.or = toList(connection, or).stream().map(v -> PropertyShape.Factory.getPropertyShapesInner(connection, nodeShape, (Resource) v)).collect(Collectors.toList());
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.OR, null, true))) {
-			Resource orList = stream.map(Statement::getObject).map(v -> (Resource) v).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:or on " + id));
-			or = toList(connection, orList).stream().map(v -> PropertyShape.Factory.getPropertyShapesInner(connection, nodeShape, (Resource) v)).collect(Collectors.toList());
-		}
 	}
-
-
 
 
 	@Override
@@ -69,7 +61,6 @@ public class OrPropertyShape extends PropertyShape {
 				.distinct().collect(Collectors.toList());
 
 
-
 		if (iteratorDataTypes.size() > 1) {
 			throw new UnsupportedOperationException("No support for OR shape with mix between aggregate and raw triples");
 		}
@@ -80,12 +71,12 @@ public class OrPropertyShape extends PropertyShape {
 		if (iteratorData == IteratorData.tripleBased) {
 
 			List<Path> collect = getPaths().stream().distinct().collect(Collectors.toList());
-			if(collect.size()>1){
+			if (collect.size() > 1) {
 				iteratorData = IteratorData.aggregated;
 			}
 		}
 
-			PlanNode ret;
+		PlanNode ret;
 
 
 		if (iteratorData == IteratorData.tripleBased) {
@@ -96,10 +87,8 @@ public class OrPropertyShape extends PropertyShape {
 				equalsJoin = new EqualsJoin(equalsJoin, unionAll(plannodes.get(i)), true);
 			}
 
-			ret =  new LoggingNode(equalsJoin);
-		}
-
-		else if (iteratorData == IteratorData.aggregated) {
+			ret = new LoggingNode(equalsJoin);
+		} else if (iteratorData == IteratorData.aggregated) {
 
 			PlanNode innerJoin = new LoggingNode(new InnerJoin(unionAll(plannodes.get(0)), unionAll(plannodes.get(1)), null, null));
 
@@ -107,13 +96,13 @@ public class OrPropertyShape extends PropertyShape {
 				innerJoin = new LoggingNode(new InnerJoin(innerJoin, unionAll(plannodes.get(i)), null, null));
 			}
 
-			ret =  new LoggingNode(innerJoin);
-		}else{
+			ret = new LoggingNode(innerJoin);
+		} else {
 			throw new IllegalStateException("Should not get here!");
 
 		}
 
-		if(printPlans){
+		if (printPlans) {
 			String planAsGraphiz = getPlanAsGraphvizDot(ret, shaclSailConnection);
 			logger.info(planAsGraphiz);
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
@@ -12,15 +12,11 @@ import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
-import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PatternFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
@@ -53,7 +49,7 @@ public class PatternPropertyShape extends PathPropertyShape {
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans, boolean assumeBaseSailValid) {
 
-		PlanNode invalidValues =  StandardisedPlanHelper.getGenericSingleObjectPlan(
+		PlanNode invalidValues = StandardisedPlanHelper.getGenericSingleObjectPlan(
 			shaclSailConnection,
 			nodeShape,
 			(parent, trueNode, falseNode) -> new PatternFilter(parent, trueNode, falseNode, pattern, flags),
@@ -68,20 +64,6 @@ public class PatternPropertyShape extends PathPropertyShape {
 		return new EnrichWithShape(invalidValues, this);
 
 	}
-
-	@Override
-	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		boolean requiresEvalutation = false;
-		if (nodeShape instanceof TargetClass) {
-			Resource targetClass = ((TargetClass) nodeShape).targetClass;
-			try (RepositoryConnection addedStatementsConnection = addedStatements.getConnection()) {
-				requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
-			}
-		} else {
-			requiresEvalutation = true;
-		}
-
-		return super.requiresEvaluation(addedStatements, removedStatements) | requiresEvalutation;	}
 
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
@@ -38,12 +38,10 @@ public class PatternPropertyShape extends PathPropertyShape {
 	private final Optional<String> flags;
 	private static final Logger logger = LoggerFactory.getLogger(PatternPropertyShape.class);
 
-	PatternPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape) {
+	PatternPropertyShape(Resource id, SailRepositoryConnection connection, NodeShape nodeShape, String pattern) {
 		super(id, connection, nodeShape);
 
-		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.PATTERN, null, true))) {
-			pattern = stream.map(Statement::getObject).map(Value::stringValue).findAny().orElseThrow(() -> new RuntimeException("Expected to find sh:pattern on " + id));
-		}
+		this.pattern = pattern;
 
 		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(id, SHACL.FLAGS, null, true))) {
 			flags = stream.map(Statement::getObject).map(Value::stringValue).findAny();

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
@@ -144,113 +144,50 @@ public class PropertyShape implements PlanGenerator, RequiresEvalutation {
 		static List<PropertyShape> getPropertyShapesInner(SailRepositoryConnection connection, NodeShape nodeShape, Resource propertyShapeId) {
 			List<PropertyShape> propertyShapes = new ArrayList<>(2);
 
-			if (hasMinCount(propertyShapeId, connection)) {
-				propertyShapes.add(new MinCountPropertyShape(propertyShapeId, connection, nodeShape));
+			ShaclProperties shaclProperties = new ShaclProperties(propertyShapeId, connection);
+
+			if (shaclProperties.minCount != null) {
+				propertyShapes.add(new MinCountPropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.minCount));
+			}
+			if (shaclProperties.maxCount != null) {
+				propertyShapes.add(new MaxCountPropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.maxCount));
+			}
+			if (shaclProperties.datatype != null) {
+				propertyShapes.add(new DatatypePropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.datatype));
+			}
+			if(shaclProperties.or != null){
+				propertyShapes.add(new OrPropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.or));
+			}
+			if(shaclProperties.minLength != null){
+				propertyShapes.add(new MinLengthPropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.minLength));
+			}
+			if(shaclProperties.maxLength != null){
+				propertyShapes.add(new MaxLengthPropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.maxLength));
+			}
+			if(shaclProperties.pattern != null){
+				propertyShapes.add(new PatternPropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.pattern));
+			}
+			if(shaclProperties.languageIn != null){
+				propertyShapes.add(new LanguageInPropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.languageIn));
+			}
+			if(shaclProperties.nodeKind != null){
+				propertyShapes.add(new NodeKindPropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.nodeKind));
+			}
+			if(shaclProperties.minExclusive != null){
+				propertyShapes.add(new MinExclusivePropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.minExclusive));
+			}
+			if(shaclProperties.maxExclusive != null){
+				propertyShapes.add(new MaxExclusivePropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.maxExclusive));
+			}
+			if(shaclProperties.maxInclusive != null){
+				propertyShapes.add(new MaxInclusivePropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.maxInclusive));
+			}
+			if(shaclProperties.minInclusive != null){
+				propertyShapes.add(new MinInclusivePropertyShape(propertyShapeId, connection, nodeShape, shaclProperties.minInclusive));
 			}
 
-			if (hasMaxCount(propertyShapeId, connection)) {
-				propertyShapes.add(new MaxCountPropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasDatatype(propertyShapeId, connection)) {
-				propertyShapes.add(new DatatypePropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasOr(propertyShapeId, connection)) {
-				propertyShapes.add(new OrPropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasMinLength(propertyShapeId, connection)) {
-				propertyShapes.add(new MinLengthPropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasMaxLength(propertyShapeId, connection)) {
-				propertyShapes.add(new MaxLengthPropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasPattern(propertyShapeId, connection)) {
-				propertyShapes.add(new PatternPropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasLanguageIn(propertyShapeId, connection)) {
-				propertyShapes.add(new LanguageInPropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasNodeKind(propertyShapeId, connection)) {
-				propertyShapes.add(new NodeKindPropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasMinExclusive(propertyShapeId, connection)) {
-				propertyShapes.add(new MinExclusivePropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasMaxExclusive(propertyShapeId, connection)) {
-				propertyShapes.add(new MaxExclusivePropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasMaxInclusive(propertyShapeId, connection)) {
-				propertyShapes.add(new MaxInclusivePropertyShape(propertyShapeId, connection, nodeShape));
-			}
-
-			if (hasMinInclusive(propertyShapeId, connection)) {
-				propertyShapes.add(new MinInclusivePropertyShape(propertyShapeId, connection, nodeShape));
-			}
 			return propertyShapes;
 		}
-
-		private static boolean hasOr(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.OR, null, true);
-		}
-
-
-		private static boolean hasMinCount(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.MIN_COUNT, null, true);
-		}
-
-		private static boolean hasMaxCount(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.MAX_COUNT, null, true);
-		}
-
-		private static boolean hasDatatype(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.DATATYPE, null, true);
-		}
-
-		private static boolean hasMinLength(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.MIN_LENGTH, null, true);
-		}
-
-		private static boolean hasMaxLength(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.MAX_LENGTH, null, true);
-		}
-
-		private static boolean hasPattern(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.PATTERN, null, true);
-		}
-
-		private static boolean hasLanguageIn(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.LANGUAGE_IN, null, true);
-		}
-
-		private static boolean hasNodeKind(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.NODE_KIND_PROP, null, true);
-		}
-
-		private static boolean hasMinExclusive(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.MIN_EXCLUSIVE, null, true);
-		}
-
-		private static boolean hasMaxExclusive(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.MAX_EXCLUSIVE, null, true);
-		}
-
-		private static boolean hasMaxInclusive(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.MAX_INCLUSIVE, null, true);
-		}
-
-		private static boolean hasMinInclusive(Resource id, SailRepositoryConnection connection) {
-			return connection.hasStatement(id, SHACL.MIN_INCLUSIVE, null, true);
-		}
-
 	}
 }
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
@@ -64,7 +64,7 @@ public class PropertyShape implements PlanGenerator, RequiresEvalutation {
 
 	@Override
 	public boolean requiresEvaluation(Repository addedStatements, Repository removedStatements) {
-		return false;
+		return nodeShape.requiresEvaluation(addedStatements, removedStatements);
 	}
 
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ShaclProperties.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ShaclProperties.java
@@ -1,0 +1,129 @@
+package org.eclipse.rdf4j.sail.shacl.AST;
+
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+
+import java.util.stream.Stream;
+
+public class ShaclProperties {
+
+
+	Resource or;
+	Long minCount;
+	Long maxCount;
+
+	Resource datatype;
+
+	Long minLength;
+	Long maxLength;
+
+	Resource languageIn;
+	Resource nodeKind;
+
+	Literal minExclusive;
+	Literal maxExclusive;
+	Literal minInclusive;
+	Literal maxInclusive;
+
+	String pattern;
+
+
+	public ShaclProperties(Resource propertyShapeId, SailRepositoryConnection connection) {
+
+		try (Stream<Statement> stream = Iterations.stream(connection.getStatements(propertyShapeId, null, null))) {
+			stream.forEach(statement -> {
+				String predicate = statement.getPredicate().toString();
+				Value object = statement.getObject();
+				switch (predicate) {
+					case "http://www.w3.org/ns/shacl#or":
+						if (or != null) {
+							throw new IllegalStateException("sh:or already populated");
+						}
+						or = (Resource) object;
+						break;
+					case "http://www.w3.org/ns/shacl#languageIn":
+						if (languageIn != null) {
+							throw new IllegalStateException("sh:languageIn already populated");
+						}
+						languageIn = (Resource) object;
+						break;
+					case "http://www.w3.org/ns/shacl#nodeKind":
+						if (nodeKind != null) {
+							throw new IllegalStateException("sh:nodeKind already populated");
+						}
+						nodeKind = (Resource) object;
+						break;
+					case "http://www.w3.org/ns/shacl#datatype":
+						if (datatype != null) {
+							throw new IllegalStateException("sh:datatype already populated");
+						}
+						datatype = (Resource) object;
+						break;
+					case "http://www.w3.org/ns/shacl#minCount":
+						if (minCount != null) {
+							throw new IllegalStateException("sh:minCount aleady populated");
+						}
+						minCount = ((Literal) object).longValue();
+						break;
+					case "http://www.w3.org/ns/shacl#maxCount":
+						if (maxCount != null) {
+							throw new IllegalStateException("sh:maxCount aleady populated");
+						}
+						maxCount = ((Literal) object).longValue();
+						break;
+					case "http://www.w3.org/ns/shacl#minLength":
+						if (minLength != null) {
+							throw new IllegalStateException("sh:minLength aleady populated");
+						}
+						minLength = ((Literal) object).longValue();
+						break;
+					case "http://www.w3.org/ns/shacl#maxLength":
+						if (maxLength != null) {
+							throw new IllegalStateException("sh:maxLength aleady populated");
+						}
+						maxLength = ((Literal) object).longValue();
+						break;
+					case "http://www.w3.org/ns/shacl#minExclusive":
+						if (minExclusive != null) {
+							throw new IllegalStateException("sh:minExclusive aleady populated");
+						}
+						minExclusive = (Literal) object;
+						break;
+					case "http://www.w3.org/ns/shacl#maxExclusive":
+						if (maxExclusive != null) {
+							throw new IllegalStateException("sh:maxExclusive aleady populated");
+						}
+						maxExclusive = (Literal) object;
+						break;
+					case "http://www.w3.org/ns/shacl#minInclusive":
+						if (minInclusive != null) {
+							throw new IllegalStateException("sh:minInclusive aleady populated");
+						}
+						minInclusive = (Literal) object;
+						break;
+					case "http://www.w3.org/ns/shacl#maxInclusive":
+						if (maxInclusive != null) {
+							throw new IllegalStateException("sh:maxInclusive aleady populated");
+						}
+						maxInclusive = (Literal) object;
+						break;
+					case "http://www.w3.org/ns/shacl#pattern":
+						if (pattern != null) {
+							throw new IllegalStateException("sh:pattern aleady populated");
+						}
+						pattern = object.stringValue();
+						break;
+				}
+
+
+			});
+		}
+
+	}
+
+
+}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetClass.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetClass.java
@@ -67,7 +67,7 @@ public class TargetClass extends NodeShape {
 			requiresEvalutation = addedStatementsConnection.hasStatement(null, RDF.TYPE, targetClass, false);
 		}
 
-		return super.requiresEvaluation(addedStatements, removedStatements) || requiresEvalutation;
+		return requiresEvalutation;
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -331,7 +331,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		// we don't support revalidation of all data when changing the shacl shapes,
 		// so no need to check if the shapes have changed
 		if (addedStatementsSet.isEmpty() && removedStatementsSet.isEmpty()) {
-			logger.debug("Nothing has changed, nothing to debug.");
+			logger.debug("Nothing has changed, nothing to validate.");
 			return;
 		}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailSchema.java
@@ -8,7 +8,6 @@
 package org.eclipse.rdf4j.sail.shacl.config;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LiteralComparatorFilter.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LiteralComparatorFilter.java
@@ -17,7 +17,6 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.query.algebra.evaluation.util.ValueComparator;
 
-import java.math.BigDecimal;
 import java.util.function.Function;
 
 /**

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/BulkedExternalInnerJoinTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/BulkedExternalInnerJoinTest.java
@@ -3,7 +3,6 @@ package org.eclipse.rdf4j.sail.shacl;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
@@ -9,37 +9,9 @@
 package org.eclipse.rdf4j.sail.shacl;
 
 import org.eclipse.rdf4j.IsolationLevel;
-import org.eclipse.rdf4j.IsolationLevels;
-import org.eclipse.rdf4j.common.io.IOUtil;
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Model;
-import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.eclipse.rdf4j.repository.RepositoryException;
-import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.Rio;
-import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 /**
  * @author Håvard Ottestad

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/Utils.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/Utils.java
@@ -9,7 +9,6 @@
 package org.eclipse.rdf4j.sail.shacl;
 
 import org.eclipse.rdf4j.IsolationLevels;
-import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
@@ -19,7 +18,6 @@ import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
-import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexBenchmark.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexBenchmark.java
@@ -8,18 +8,21 @@
 
 package org.eclipse.rdf4j.sail.shacl.benchmark;
 
-import org.apache.commons.io.FileUtils;
+import ch.qos.logback.classic.Logger;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.IsolationLevels;
+import org.eclipse.rdf4j.common.iteration.Iterations;
+import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.FOAF;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.shacl.AST.ShaclProperties;
 import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.Utils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -31,13 +34,12 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad
@@ -47,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode({Mode.AverageTime})
 @Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G", "-Xmn4G", "-XX:+UseSerialGC"})
 //@Fork(value = 1, jvmArgs = {"-Xms8G", "-Xmx8G", "-Xmn4G", "-XX:+UseSerialGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=15s,duration=120s,filename=recording.jfr,settings=ProfilingAggressive.jfc", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
-@Measurement(iterations = 20)
+@Measurement(iterations = 30)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ComplexBenchmark {
 
@@ -67,6 +69,8 @@ public class ComplexBenchmark {
 	@Setup(Level.Iteration)
 	public void setUp() {
 		System.gc();
+		Logger root = (Logger) LoggerFactory.getLogger(ShaclSailConnection.class.getName());
+		root.setLevel(ch.qos.logback.classic.Level.INFO);
 	}
 
 
@@ -76,17 +80,110 @@ public class ComplexBenchmark {
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
+
 			connection.begin(IsolationLevels.SNAPSHOT);
+			connection.prepareUpdate(transaction1).execute();
+			connection.commit();
+
+			connection.begin(IsolationLevels.SNAPSHOT);
+			connection.prepareUpdate(transaction2).execute();
+			connection.commit();
+
+		}
+
+		repository.shutDown();
+
+	}
+
+
+	@Benchmark
+	public void shaclNoTransactions() throws Exception {
+
+		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
+
+		repository.shutDown();
+
+	}
+
+	SailRepository memoryStore = new SailRepository(new MemoryStore());
+
+	{
+		memoryStore.init();
+
+		try (SailRepositoryConnection connection = memoryStore.getConnection()) {
+			connection.begin(IsolationLevels.NONE);
+			try {
+				connection.add(ComplexBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/shacl.ttl"), "", RDFFormat.TURTLE);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
 			connection.commit();
 		}
+	}
+
+	@Benchmark
+	public void shaclPropertiesSwitch() {
+
+		try (SailRepositoryConnection connection = memoryStore.getConnection()) {
+
+			try (Stream<Statement> stream = Iterations.stream(connection.getStatements(null, SHACL.PROPERTY, null))) {
+				stream.map(Statement::getObject).forEach(o -> {
+					new ShaclProperties((Resource) o, connection);
+				});
+			}
+
+		}
+
+	}
+
+
+	@Benchmark
+	public void shaclEmptyTransactions() throws Exception {
+
+		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
+		((ShaclSail) repository.getSail()).setParallelValidation(false);
+
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 
-				connection.begin(IsolationLevels.SNAPSHOT);
-				connection.prepareUpdate(transaction1).execute();
-				connection.commit();
+			connection.begin(IsolationLevels.SNAPSHOT);
+			connection.commit();
+
+		}
+
+		repository.shutDown();
+
+	}
+
+	@Benchmark
+	public void shaclNothingToValidateTransactions() throws Exception {
+
+		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
+		((ShaclSail) repository.getSail()).setParallelValidation(false);
+
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
 
 			connection.begin(IsolationLevels.SNAPSHOT);
+			connection.add(connection.getValueFactory().createBNode(), RDFS.LABEL, connection.getValueFactory().createLiteral(""));
+			connection.commit();
+
+		}
+
+		repository.shutDown();
+
+	}
+
+	@Benchmark
+	public void shaclParallelCacheSingleTransactionNoIsolation() throws Exception {
+
+		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
+
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+
+			connection.begin(IsolationLevels.NONE);
+			connection.prepareUpdate(transaction1).execute();
+
 			connection.prepareUpdate(transaction2).execute();
 			connection.commit();
 
@@ -102,11 +199,6 @@ public class ComplexBenchmark {
 		SailRepository repository = new SailRepository(Utils.getInitializedShaclSail("complexBenchmark/shacl.ttl"));
 
 		((ShaclSail) repository.getSail()).setCacheSelectNodes(false);
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin(IsolationLevels.SNAPSHOT);
-			connection.commit();
-		}
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 
@@ -133,11 +225,6 @@ public class ComplexBenchmark {
 		((ShaclSail) repository.getSail()).setParallelValidation(false);
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin(IsolationLevels.SNAPSHOT);
-			connection.commit();
-		}
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
 
 			connection.begin(IsolationLevels.SNAPSHOT);
 			connection.prepareUpdate(transaction1).execute();
@@ -154,7 +241,6 @@ public class ComplexBenchmark {
 	}
 
 
-
 	@Benchmark
 	public void shacl() throws Exception {
 
@@ -162,11 +248,6 @@ public class ComplexBenchmark {
 
 		((ShaclSail) repository.getSail()).setParallelValidation(false);
 		((ShaclSail) repository.getSail()).setCacheSelectNodes(false);
-
-		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.begin(IsolationLevels.SNAPSHOT);
-			connection.commit();
-		}
 
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/DatatypeBenchmarkEmpty.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/DatatypeBenchmarkEmpty.java
@@ -9,17 +9,14 @@
 package org.eclipse.rdf4j.sail.shacl.benchmark;
 
 import org.eclipse.rdf4j.IsolationLevels;
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.eclipse.rdf4j.sail.shacl.ShaclSail;
 import org.eclipse.rdf4j.sail.shacl.Utils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -37,7 +34,6 @@ import org.openjdk.jmh.annotations.Warmup;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/DatatypeBenchmarkLinear.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/DatatypeBenchmarkLinear.java
@@ -9,16 +9,13 @@
 package org.eclipse.rdf4j.sail.shacl.benchmark;
 
 import org.eclipse.rdf4j.IsolationLevels;
-import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
-import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
-import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.sail.shacl.Utils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -37,7 +34,6 @@ import org.openjdk.jmh.annotations.Warmup;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 /**
  * @author Håvard Ottestad

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/config/ShaclSailConfigTest.java
@@ -7,20 +7,25 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.*;
-
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.impl.TreeModel;
-import org.eclipse.rdf4j.model.impl.TreeModelFactory;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.sail.config.SailConfigException;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.CACHE_SELECT_NODES;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.GLOBAL_LOG_VALIDATION_EXECUTION;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.IGNORE_NO_SHAPES_LOADED_EXCEPTION;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.LOG_VALIDATION_PLANS;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.LOG_VALIDATION_VIOLATIONS;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.PARALLEL_VALIDATION;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.UNDEFINED_TARGET_VALIDATES_ALL_SUBJECTS;
+import static org.eclipse.rdf4j.sail.shacl.config.ShaclSailSchema.VALIDATION_ENABLED;
 
 public class ShaclSailConfigTest {
 

--- a/shacl/src/test/resources/test-cases/complex/dcat/valid/case2/query1.rq
+++ b/shacl/src/test/resources/test-cases/complex/dcat/valid/case2/query1.rq
@@ -1,0 +1,18 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+
+INSERT DATA {
+
+
+[] rdfs:label "hello".
+
+}
+


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1286  eclipse/rdf4j#1287.

Briefly describe the changes proposed in this PR:

* parse shacl predicates into a java object
* better support for requiresEvaluation
* skip validation if there are no changes
