### PR TITLE
Fix eclipse/rdf4j#1293 optimizer for regex calls now handles non-var arguments

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizer.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizer.java
@@ -51,7 +51,7 @@ public class RegexAsStringFunctionOptimizer implements QueryOptimizer {
             final ValueExpr flagsArg = node.getFlagsArg();
             if (flagsArg == null || flagsArg.toString().isEmpty()) {
                 //if we have no flags then we can not be in case insensitive mode
-                if (node.getPatternArg() instanceof ValueConstant && node.getArg() instanceof Var) {
+                if (node.getPatternArg() instanceof ValueConstant) {
                     ValueConstant vc = (ValueConstant) node.getPatternArg();
                     String regex = vc.getValue().stringValue();
                     final boolean anchoredAtStart = regex.startsWith("^");

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizierTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/RegexAsStringFunctionOptimizierTest.java
@@ -88,6 +88,16 @@ public class RegexAsStringFunctionOptimizierTest {
 
         testOptimizer(unoptimizedQuery, unoptimizedQuery);
     }
+    
+    @Test
+    public void testContainsFunction()
+            throws MalformedQueryException {
+        String optimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(CONTAINS(STR(?o), 'a'))}";
+        String unoptimizedQuery = "SELECT ?o WHERE {?s ?p ?o . FILTER(REGEX(STR(?o), 'a'))}";
+        
+
+        testOptimizer(optimizedQuery, unoptimizedQuery);
+    }
 
     @Test
     public void testRealRegexDoesNotRedirect() {


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1293 .

The previous optimizer for replacing regex calls with contains,strstarts or strends did not work if the argument to the Regex was not a var.
e.g. REGEX(STR(?x), 'lala') 
was not optimized.
This fixes this and adds a test for it.