### PR TITLE
Issues/1337 fix spin tests

### DIFF
--- a/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/SpinRDFSMemoryRepositoryConnectionTest.java
+++ b/compliance/store/src/test/java/org/eclipse/rdf4j/repository/sail/memory/SpinRDFSMemoryRepositoryConnectionTest.java
@@ -34,6 +34,6 @@ public class SpinRDFSMemoryRepositoryConnectionTest extends RepositoryConnection
 	protected Repository createRepository()
 			throws MalformedQueryException, UnsupportedQueryLanguageException, SailException, IOException {
 		return new SailRepository(
-				new SpinSail(new SchemaCachingRDFSInferencer(new DedupingInferencer(new MemoryStore()))));
+				new SpinSail(new SchemaCachingRDFSInferencer(new DedupingInferencer(new MemoryStore()), false)));
 	}
 }

--- a/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
+++ b/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpifSailTest.java
@@ -64,7 +64,7 @@ public class SpifSailTest {
 	public void setup() throws RepositoryException {
 		NotifyingSail baseSail = new MemoryStore();
 		DedupingInferencer deduper = new DedupingInferencer(baseSail);
-		NotifyingSail rdfsInferencer = new SchemaCachingRDFSInferencer(deduper);
+		NotifyingSail rdfsInferencer = new SchemaCachingRDFSInferencer(deduper, false);
 		SpinSail spinSail = new SpinSail(rdfsInferencer);
 		repo = new SailRepository(spinSail);
 		repo.initialize();

--- a/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpinSailTest.java
+++ b/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SpinSailTest.java
@@ -47,7 +47,7 @@ public class SpinSailTest {
 	public void setup() throws RepositoryException {
 		NotifyingSail baseSail = new MemoryStore();
 		DedupingInferencer deduper = new DedupingInferencer(baseSail);
-		SchemaCachingRDFSInferencer rdfsInferencer = new SchemaCachingRDFSInferencer(deduper);
+		SchemaCachingRDFSInferencer rdfsInferencer = new SchemaCachingRDFSInferencer(deduper, false);
 		SpinSail spinSail = new SpinSail(rdfsInferencer);
 		repo = new SailRepository(spinSail);
 		repo.initialize();

--- a/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SplSailTest.java
+++ b/sail-spin/src/test/java/org/eclipse/rdf4j/sail/spin/SplSailTest.java
@@ -49,7 +49,7 @@ public class SplSailTest {
 	public void setup() throws RepositoryException {
 		NotifyingSail baseSail = new MemoryStore();
 		DedupingInferencer deduper = new DedupingInferencer(baseSail);
-		ForwardChainingRDFSInferencer rdfsInferencer = new ForwardChainingRDFSInferencer(deduper);
+		NotifyingSail rdfsInferencer = new SchemaCachingRDFSInferencer(deduper, false);
 		SpinSail spinSail = new SpinSail(rdfsInferencer);
 		repo = new SailRepository(spinSail);
 		repo.initialize();


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1337 .

Briefly describe the changes proposed in this PR:

* fix test that doesn't handle graphs properly by simply reducing the amount of inference
* introduce SchemaCachingRDFSInferencer to all spin tests
* reduce amount of inference on all those tests to improve test performance slightly