### PR TITLE
eclipse/rdf4j#1229 compliance tests for Lucene itself

### DIFF
--- a/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailIndexedPropertiesTest.java
+++ b/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailIndexedPropertiesTest.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+/**
+ * @author jeen
+ *
+ */
+public class LuceneSailIndexedPropertiesTest extends AbstractLuceneSailIndexedPropertiesTest {
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailIndexedPropertiesTest#configure(org.eclipse.rdf4j.sail.lucene.
+	 * LuceneSail)
+	 */
+	@Override
+	protected void configure(LuceneSail sail) {
+		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneIndex.class.getName());
+		sail.setParameter(LuceneSail.LUCENE_RAMDIR_KEY, "true");
+	}
+
+}

--- a/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
+++ b/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import java.io.IOException;
+
+/**
+ * @author jeen
+ *
+ */
+public class LuceneSailTest extends AbstractLuceneSailTest {
+
+	/* (non-Javadoc)
+	 * @see org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailTest#configure(org.eclipse.rdf4j.sail.lucene.LuceneSail)
+	 */
+	@Override
+	protected void configure(LuceneSail sail) throws IOException {
+		sail.setParameter(LuceneSail.INDEX_CLASS_KEY, LuceneIndex.class.getName());
+		sail.setParameter(LuceneSail.LUCENE_RAMDIR_KEY, "true");
+	}
+
+}

--- a/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
+++ b/compliance/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneSailTest.java
@@ -15,7 +15,9 @@ import java.io.IOException;
  */
 public class LuceneSailTest extends AbstractLuceneSailTest {
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
+	 * 
 	 * @see org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailTest#configure(org.eclipse.rdf4j.sail.lucene.LuceneSail)
 	 */
 	@Override


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1229 .

Briefly describe the changes proposed in this PR:

* execute lucene testsuite for the actual lucene sail itself

