### PR TITLE
Fixes: #1363 Make substring function pass xpath examples

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/Substring.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/Substring.java
@@ -60,7 +60,7 @@ public class Substring implements Function {
 				int startIndex = 0;
 				if (startIndexValue instanceof Literal) {
 					// If it is not an int we need to round it per spec
-					int startLiteral = roundLiteral((Literal) startIndexValue);
+					int startLiteral = intFromLiteral((Literal) startIndexValue);
 
 					try {
 						// xpath:substring startIndex is 1-based.
@@ -80,7 +80,7 @@ public class Substring implements Function {
 				int endIndex = lexicalValue.length();
 				if (lengthValue instanceof Literal) {
 					try {
-						int length = roundLiteral((Literal) lengthValue);
+						int length = intFromLiteral((Literal) lengthValue);
 						if (length < 1) {
 							return convert("", literal, valueFactory);
 						}
@@ -125,7 +125,7 @@ public class Substring implements Function {
 		}
 	}
 
-	public static int roundLiteral(Literal literal) throws ValueExprEvaluationException {
+	public static int intFromLiteral(Literal literal) throws ValueExprEvaluationException {
 
 		IRI datatype = literal.getDatatype();
 
@@ -133,12 +133,6 @@ public class Substring implements Function {
 		if (datatype != null && XMLDatatypeUtil.isNumericDatatype(datatype)) {
 			if (XMLDatatypeUtil.isIntegerDatatype(datatype)) {
 				return literal.intValue();
-			} else if (XMLDatatypeUtil.isDecimalDatatype(datatype)) {
-				BigDecimal rounded = literal.decimalValue().setScale(0, RoundingMode.HALF_UP);
-				return rounded.intValue();
-			} else if (XMLDatatypeUtil.isFloatingPointDatatype(datatype)) {
-				double ceilingValue = Math.round(literal.doubleValue());
-				return (int) ceilingValue;
 			} else {
 				throw new ValueExprEvaluationException("unexpected datatype for function operand: " + literal);
 			}

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/Substring.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/Substring.java
@@ -81,11 +81,13 @@ public class Substring implements Function {
 				if (lengthValue instanceof Literal) {
 					try {
 						int length = roundLiteral((Literal) lengthValue);
-						if (length < 1)
+						if (length < 1) {
 							return convert("", literal, valueFactory);
+						}
 						endIndex = Math.min(startIndex + length, endIndex);
-						if (endIndex < 0)
+						if (endIndex < 0) {
 							return convert("", literal, valueFactory);
+						}
 					} catch (NumberFormatException e) {
 						throw new ValueExprEvaluationException(
 								"illegal length value (expected int value): " + lengthValue);

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/SubstringTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/SubstringTest.java
@@ -15,6 +15,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.junit.After;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -80,12 +81,7 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(4);
 		Literal length = f.createLiteral(5);
 
-		try {
-			substrFunc.evaluate(f, pattern, startIndex, length);
-			fail("illegal length spec should have resulted in error");
-		} catch (ValueExprEvaluationException e) {
-			// do nothing, expected
-		}
+		assertEquals("bar", substrFunc.evaluate(f, pattern, startIndex, length).getLabel());
 	}
 
 	@Test
@@ -99,5 +95,108 @@ public class SubstringTest {
 		} catch (ValueExprEvaluationException e) {
 			// do nothing, expected
 		}
+	}
+
+	@Test
+	public void testEvaluateStartBefore1() {
+		Literal pattern = f.createLiteral("ABC");
+		Literal startIndex = f.createLiteral(0);
+		Literal length = f.createLiteral(1);
+		try {
+			Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+
+			assertTrue(result.getLabel().equals(""));
+		} catch (ValueExprEvaluationException e) {
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testXpathExamples1() {
+		Literal pattern = f.createLiteral("motor car");
+		Literal startIndex = f.createLiteral(6);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex);
+		assertEquals(" car", result.getLabel()));
+	}
+
+	@Test
+	public void testXpathExamples2() {
+		Literal pattern = f.createLiteral("metadata");
+		Literal startIndex = f.createLiteral(4);
+		Literal length = f.createLiteral(3);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		assertEquals("ada", result.getLabel()));
+	}
+
+	@Test
+	public void testXpathExamples3() {
+		Literal pattern = f.createLiteral("12345");
+		Literal startIndex = f.createLiteral(1.5);
+		Literal length = f.createLiteral(2.6);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		assertEquals("234", result.getLabel()));
+	}
+
+	@Test
+	public void testXpathExamples3int() {
+		Literal pattern = f.createLiteral("12345");
+		Literal startIndex = f.createLiteral(2);
+		Literal length = f.createLiteral(3);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		assertEquals("234", result.getLabel()));
+	}
+
+	@Test
+	public void testXpathExamples4() {
+		Literal pattern = f.createLiteral("12345");
+		Literal startIndex = f.createLiteral(0);
+		Literal length = f.createLiteral(3);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		assertEquals("12", result.getLabel()));
+	}
+
+	@Test
+	public void testXpathExamples5() {
+		Literal pattern = f.createLiteral("12345");
+		Literal startIndex = f.createLiteral(5);
+		Literal length = f.createLiteral(-3);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		assertEquals("", result.getLabel()));		
+	}
+
+	@Test
+	public void testXpathExamples6() {
+		Literal pattern = f.createLiteral("12345");
+		Literal startIndex = f.createLiteral(-3);
+		Literal length = f.createLiteral(5);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		assertEquals("1", result.getLabel()));
+	}
+
+	@Test
+	public void testXpathExamples7() {
+		Literal pattern = f.createLiteral("12345");
+		Literal startIndex = f.createLiteral(1);
+		Literal length = f.createLiteral(Float.NaN);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		assertEquals("", result.getLabel()));
+	}
+
+	@Test
+	public void testXpathExamples8() {
+		Literal pattern = f.createLiteral("12345");
+		Literal startIndex = f.createLiteral(-42);
+		Literal length = f.createLiteral(Float.POSITIVE_INFINITY);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		assertEquals("12345", result.getLabel()));
+	}
+
+	@Test
+	public void testXpathExamples9() {
+		Literal pattern = f.createLiteral("12345");
+		Literal startIndex = f.createLiteral(Float.NEGATIVE_INFINITY);
+		Literal length = f.createLiteral(Float.POSITIVE_INFINITY);
+		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		assertEquals("", result.getLabel()));
 	}
 }

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/SubstringTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/SubstringTest.java
@@ -116,7 +116,7 @@ public class SubstringTest {
 		Literal pattern = f.createLiteral("motor car");
 		Literal startIndex = f.createLiteral(6);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex);
-		assertEquals(" car", result.getLabel()));
+		assertEquals(" car", result.getLabel());
 	}
 
 	@Test
@@ -125,7 +125,7 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(4);
 		Literal length = f.createLiteral(3);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("ada", result.getLabel()));
+		assertEquals("ada", result.getLabel());
 	}
 
 	@Test
@@ -134,7 +134,7 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(1.5);
 		Literal length = f.createLiteral(2.6);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("234", result.getLabel()));
+		assertEquals("234", result.getLabel());
 	}
 
 	@Test
@@ -143,7 +143,7 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(2);
 		Literal length = f.createLiteral(3);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("234", result.getLabel()));
+		assertEquals("234", result.getLabel());
 	}
 
 	@Test
@@ -152,7 +152,7 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(0);
 		Literal length = f.createLiteral(3);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("12", result.getLabel()));
+		assertEquals("12", result.getLabel());
 	}
 
 	@Test
@@ -161,7 +161,7 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(5);
 		Literal length = f.createLiteral(-3);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("", result.getLabel()));		
+		assertEquals("", result.getLabel());
 	}
 
 	@Test
@@ -170,7 +170,7 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(-3);
 		Literal length = f.createLiteral(5);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("1", result.getLabel()));
+		assertEquals("1", result.getLabel());
 	}
 
 	@Test
@@ -179,7 +179,7 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(1);
 		Literal length = f.createLiteral(Float.NaN);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("", result.getLabel()));
+		assertEquals("", result.getLabel());
 	}
 
 	@Test
@@ -188,7 +188,7 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(-42);
 		Literal length = f.createLiteral(Float.POSITIVE_INFINITY);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("12345", result.getLabel()));
+		assertEquals("12345", result.getLabel());
 	}
 
 	@Test
@@ -197,6 +197,6 @@ public class SubstringTest {
 		Literal startIndex = f.createLiteral(Float.NEGATIVE_INFINITY);
 		Literal length = f.createLiteral(Float.POSITIVE_INFINITY);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("", result.getLabel()));
+		assertEquals("", result.getLabel());
 	}
 }

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/SubstringTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/SubstringTest.java
@@ -133,8 +133,13 @@ public class SubstringTest {
 		Literal pattern = f.createLiteral("12345");
 		Literal startIndex = f.createLiteral(1.5);
 		Literal length = f.createLiteral(2.6);
-		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("234", result.getLabel());
+		try {
+			Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+			fail("illegal use of float args hould have resulted in error");
+		} catch (ValueExprEvaluationException e) {
+			// do nothing, expected
+			// this is unlike the xpath standard as sparql only allows int input
+		}
 	}
 
 	@Test
@@ -178,15 +183,22 @@ public class SubstringTest {
 		Literal pattern = f.createLiteral("12345");
 		Literal startIndex = f.createLiteral(1);
 		Literal length = f.createLiteral(Float.NaN);
-		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("", result.getLabel());
+		try {
+			Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+		} catch (ValueExprEvaluationException e) {
+			// do nothing, expected
+			// this is unlike the xpath standard as sparql only allows int input
+		}
 	}
 
 	@Test
-	public void testXpathExamples8() {
+	public void testXpathExample8Inspired() {
 		Literal pattern = f.createLiteral("12345");
 		Literal startIndex = f.createLiteral(-42);
-		Literal length = f.createLiteral(Float.POSITIVE_INFINITY);
+		// This test was inspired by the xpath test cases.
+		// However there is no Integer infinite value in java that
+		// could be used
+		Literal length = f.createLiteral(50);
 		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
 		assertEquals("12345", result.getLabel());
 	}
@@ -196,7 +208,11 @@ public class SubstringTest {
 		Literal pattern = f.createLiteral("12345");
 		Literal startIndex = f.createLiteral(Float.NEGATIVE_INFINITY);
 		Literal length = f.createLiteral(Float.POSITIVE_INFINITY);
-		Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
-		assertEquals("", result.getLabel());
+		try {
+			Literal result = substrFunc.evaluate(f, pattern, startIndex, length);
+			fail("illegal use of float args hould have resulted in error");
+		} catch (ValueExprEvaluationException e) {
+			// do nothing, expected
+		}
 	}
 }


### PR DESCRIPTION
This changes the implementation of the substring function to match the examples given in the [xpath spec 3.1](https://www.w3.org/TR/xpath-functions-31/#func-substring)

The test cases have been expanded with those examples. 
Key functional change is that we round non integer numbers. e.g. 1.5 > 2
I think numbers below zero work correctly now.

Issue: https://github.com/eclipse/rdf4j/issues/1363