### PR TITLE
Use commons-lang3 and commons-text instead of commons-lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,9 +267,14 @@
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>
-				<groupId>commons-lang</groupId>
-				<artifactId>commons-lang</artifactId>
-				<version>2.6</version>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.8.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-text</artifactId>
+				<version>1.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>

--- a/shacl/pom.xml
+++ b/shacl/pom.xml
@@ -17,9 +17,13 @@
     <description>Stacked Sail with SHACL validation capabilities</description>
 
     <dependencies>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+		<dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BufferedPlanNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BufferedPlanNode.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BufferedSplitter.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BufferedSplitter.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalLeftOuterJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalLeftOuterJoin.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.query.BindingSet;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/EmptyNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/EmptyNode.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
 import org.eclipse.rdf4j.sail.SailException;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/EnrichWithShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/EnrichWithShape.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.shacl.AST.PropertyShape;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/EqualsJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/EqualsJoin.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalFilterByPredicate.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalFilterByPredicate.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalTypeFilterNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalTypeFilterNode.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/FilterPlanNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/FilterPlanNode.java
@@ -8,8 +8,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 import org.slf4j.Logger;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/GroupByCount.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/GroupByCount.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/InnerJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/InnerJoin.java
@@ -7,8 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 import org.slf4j.Logger;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LeftOuterJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LeftOuterJoin.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LoggingNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/LoggingNode.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.sail.SailException;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ModifyTuple.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ModifyTuple.java
@@ -8,8 +8,8 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.NotImplementedException;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 
@@ -46,7 +46,7 @@ public class ModifyTuple implements PlanNode {
 
 			@Override
 			public void remove() throws SailException {
-				throw new NotImplementedException();
+				throw new NotImplementedException("Not implemented yet");
 			}
 		};
 	}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/NonUniqueTargetLang.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/NonUniqueTargetLang.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Select.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Select.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/SetFilterNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/SetFilterNode.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sail.SailException;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Sort.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Sort.java
@@ -8,14 +8,12 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.query.algebra.evaluation.util.ValueComparator;
 import org.eclipse.rdf4j.sail.SailException;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/TrimTuple.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/TrimTuple.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnBufferedPlanNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnBufferedPlanNode.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnionNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnionNode.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Unique.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Unique.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.sail.SailException;
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnorderedSelect.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnorderedSelect.java
@@ -8,7 +8,7 @@
 
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -15,10 +15,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-		</dependency>
-
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+        </dependency>
         <dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-queryalgebra-model</artifactId>

--- a/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/BuildString.java
+++ b/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/BuildString.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.spin.function.spif;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -39,7 +39,7 @@ public class BuildString implements Function {
 		for (int i = 1; i < args.length; i++) {
 			mappings.put(Integer.toString(i), args[i].stringValue());
 		}
-		String newValue = StrSubstitutor.replace(tmpl, mappings, "{?", "}");
+		String newValue = StringSubstitutor.replace(tmpl, mappings, "{?", "}");
 		return valueFactory.createLiteral(newValue);
 	}
 }

--- a/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/BuildURI.java
+++ b/spin/src/main/java/org/eclipse/rdf4j/spin/function/spif/BuildURI.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.spin.function.spif;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -39,7 +39,7 @@ public class BuildURI implements Function {
 		for (int i = 1; i < args.length; i++) {
 			mappings.put(Integer.toString(i), args[i].stringValue());
 		}
-		String newValue = StrSubstitutor.replace(tmpl, mappings, "{?", "}");
+		String newValue = StringSubstitutor.replace(tmpl, mappings, "{?", "}");
 		if (tmpl.charAt(0) == '<' && tmpl.charAt(tmpl.length() - 1) == '>') {
 			return valueFactory.createURI(newValue.substring(1, newValue.length() - 1));
 		}


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1173 .

Briefly describe the changes proposed in this PR:

* Use commons-text and commons-lang3 
* Remove commons-lang 2.x

Commons Lang 2. is 8 years old, while both commons-lang3 and commons-text are also distributed with RDF4J

Commons Text is fixed 1.3, since that's the version used by the opencsv 4 dependency