### PR TITLE
log unsupported shacl features

### DIFF
--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ShaclProperties.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ShaclProperties.java
@@ -7,6 +7,9 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -15,6 +18,8 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 public class ShaclProperties {
+
+	private static final Logger logger = LoggerFactory.getLogger(ShaclProperties.class);
 
 	List<Resource> clazz = new ArrayList<>(0);
 	List<Resource> or = new ArrayList<>(0);
@@ -168,6 +173,14 @@ public class ShaclProperties {
 					}
 					in = (Resource) object;
 					break;
+				case "http://www.w3.org/ns/shacl#property":
+					break;
+				default:
+					if (predicate.startsWith("http://www.w3.org/ns/shacl#")) {
+						logger.debug("Unsupported SHACL feature detected {} in statement {}",
+								predicate.replace("http://www.w3.org/ns/shacl#", "sh:"),
+								statement);
+					}
 				}
 
 			});

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UnknownShapesTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/UnknownShapesTest.java
@@ -1,0 +1,73 @@
+package org.eclipse.rdf4j.sail.shacl;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.LogbackException;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import ch.qos.logback.core.status.Status;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class UnknownShapesTest {
+
+	@Test
+	public void testPropertyShapes() throws IOException {
+		ch.qos.logback.classic.Logger root = (ch.qos.logback.classic.Logger) LoggerFactory
+				.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+
+		MyAppender newAppender = new MyAppender();
+		root.addAppender(newAppender);
+
+		SailRepository shaclRepository = Utils.getInitializedShaclRepository("unknownProperties.ttl", false);
+
+		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+			connection.begin();
+			connection.add(RDF.TYPE, RDF.TYPE, RDFS.RESOURCE);
+			connection.commit();
+		}
+
+		Set<String> relevantLog = newAppender.logged.stream()
+				.filter(m -> m.startsWith("Unsupported SHACL feature"))
+				.collect(Collectors.toSet());
+
+		Set<String> expected = new HashSet<>(Arrays.asList(
+				"Unsupported SHACL feature detected sh:unknownTarget in statement (http://example.com/ns#PersonShape, http://www.w3.org/ns/shacl#unknownTarget, http://www.w3.org/2000/01/rdf-schema#Class) [null]",
+				"Unsupported SHACL feature detected sh:unknownShaclProperty in statement (http://example.com/ns#PersonPropertyShape, http://www.w3.org/ns/shacl#unknownShaclProperty, \"1\"^^<http://www.w3.org/2001/XMLSchema#integer>) [null]"));
+
+		assertEquals(expected, relevantLog);
+
+	}
+
+	class MyAppender extends AppenderBase<ILoggingEvent> {
+
+		List<String> logged = new ArrayList<>();
+
+		@Override
+		public synchronized void doAppend(ILoggingEvent eventObject) {
+			logged.add(eventObject.getFormattedMessage());
+		}
+
+		@Override
+		protected void append(ILoggingEvent iLoggingEvent) {
+
+		}
+	}
+}

--- a/shacl/src/test/resources/unknownProperties.ttl
+++ b/shacl/src/test/resources/unknownProperties.ttl
@@ -1,0 +1,20 @@
+@base <http://example.com/ns> .
+@prefix ex: <http://example.com/ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+
+ex:PersonShape
+	a sh:NodeShape  ;
+	sh:targetClass rdfs:Resource ;
+        sh:unknownTarget rdfs:Class ;
+        rdfs:label "label" ;
+        rdfs:subClassOf ex:HumanShape ;
+	sh:property ex:PersonPropertyShape  .
+
+ex:PersonPropertyShape
+		sh:path rdfs:label ;
+		sh:unknownShaclProperty 1 .


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1374 .

Briefly describe the changes proposed in this PR:

* Log (debug) when an unsupported SHACL predicate is used
* 
* 
