### PR TITLE
Issues/1290 only revalidate modified shapes

### DIFF
--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/AndPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/AndPropertyShape.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -80,5 +81,25 @@ public class AndPropertyShape extends PropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.AndConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		AndPropertyShape that = (AndPropertyShape) o;
+		return and.equals(that.and);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), and);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ClassPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ClassPropertyShape.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Håvard Ottestad
@@ -235,5 +236,25 @@ public class ClassPropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.ClassConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		ClassPropertyShape that = (ClassPropertyShape) o;
+		return classResource.equals(that.classResource);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), classResource);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
@@ -17,6 +17,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -56,5 +58,25 @@ public class DatatypePropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.DatatypeConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		DatatypePropertyShape that = (DatatypePropertyShape) o;
+		return datatype.equals(that.datatype);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), datatype);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/InPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/InPropertyShape.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -64,5 +65,25 @@ public class InPropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.InConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		InPropertyShape that = (InPropertyShape) o;
+		return in.equals(that.in);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), in);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -61,5 +62,25 @@ public class LanguageInPropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.LanguageInConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		LanguageInPropertyShape that = (LanguageInPropertyShape) o;
+		return languageIn.equals(that.languageIn);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), languageIn);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
@@ -26,6 +26,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * The AST (Abstract Syntax Tree) node that represents a sh:maxCount property nodeShape restriction.
  *
@@ -122,5 +124,25 @@ public class MaxCountPropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MaxCountConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MaxCountPropertyShape that = (MaxCountPropertyShape) o;
+		return maxCount == that.maxCount;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), maxCount);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -58,5 +60,25 @@ public class MaxExclusivePropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MaxExclusiveConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MaxExclusivePropertyShape that = (MaxExclusivePropertyShape) o;
+		return maxExclusive.equals(that.maxExclusive);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), maxExclusive);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxInclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxInclusivePropertyShape.java
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -58,5 +60,25 @@ public class MaxInclusivePropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MaxInclusiveConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MaxInclusivePropertyShape that = (MaxInclusivePropertyShape) o;
+		return maxInclusive.equals(that.maxInclusive);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), maxInclusive);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
@@ -17,6 +17,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -59,4 +61,23 @@ public class MaxLengthPropertyShape extends PathPropertyShape {
 		return SourceConstraintComponent.MaxLengthConstraintComponent;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MaxLengthPropertyShape that = (MaxLengthPropertyShape) o;
+		return maxLength == that.maxLength;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), maxLength);
+	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
@@ -25,6 +25,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * The AST (Abstract Syntax Tree) node that represents a sh:minCount property nodeShape restriction.
  *
@@ -147,5 +149,25 @@ public class MinCountPropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MinCountConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MinCountPropertyShape that = (MinCountPropertyShape) o;
+		return minCount == that.minCount;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), minCount);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -58,5 +60,25 @@ public class MinExclusivePropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MinExclusiveConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MinExclusivePropertyShape that = (MinExclusivePropertyShape) o;
+		return minExclusive.equals(that.minExclusive);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), minExclusive);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinInclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinInclusivePropertyShape.java
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -57,5 +59,25 @@ public class MinInclusivePropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MinInclusiveConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MinInclusivePropertyShape that = (MinInclusivePropertyShape) o;
+		return minInclusive.equals(that.minInclusive);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), minInclusive);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
@@ -17,6 +17,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -56,5 +58,25 @@ public class MinLengthPropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.MinLengthConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		MinLengthPropertyShape that = (MinLengthPropertyShape) o;
+		return minLength == that.minLength;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), minLength);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -86,4 +88,23 @@ public class NodeKindPropertyShape extends PathPropertyShape {
 		return SourceConstraintComponent.NodeKindConstraintComponent;
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		NodeKindPropertyShape that = (NodeKindPropertyShape) o;
+		return nodeKind == that.nodeKind;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), nodeKind);
+	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeShape.java
@@ -205,4 +205,23 @@ public class NodeShape implements PlanGenerator, RequiresEvalutation, QueryGener
 	public PlanNode getTargetFilter(NotifyingSailConnection shaclSailConnection, PlanNode parent) {
 		return parent;
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		NodeShape nodeShape = (NodeShape) o;
+		return id.equals(nodeShape.id) &&
+				propertyShapes.equals(nodeShape.propertyShapes) &&
+				nodeShapes.equals(nodeShape.nodeShapes);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, propertyShapes, nodeShapes);
+	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
@@ -176,4 +176,24 @@ public class OrPropertyShape extends PropertyShape {
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.OrConstraintComponent;
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		OrPropertyShape that = (OrPropertyShape) o;
+		return or.equals(that.or);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), or);
+	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PathPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PathPropertyShape.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.UnorderedSelect;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The AST (Abstract Syntax Tree) node that represents the sh:path on a property nodeShape.
@@ -92,5 +93,25 @@ public class PathPropertyShape extends PropertyShape {
 
 	public Path getPath() {
 		return path;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		PathPropertyShape that = (PathPropertyShape) o;
+		return Objects.equals(path, that.path);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), path);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
@@ -17,6 +17,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -58,5 +60,26 @@ public class PatternPropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.PatternConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		PatternPropertyShape that = (PatternPropertyShape) o;
+		return pattern.equals(that.pattern) &&
+				Objects.equals(flags, that.flags);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), pattern, flags);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
@@ -24,6 +24,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -243,5 +244,23 @@ public class PropertyShape implements PlanGenerator, RequiresEvalutation {
 
 			return propertyShapes;
 		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		PropertyShape that = (PropertyShape) o;
+		return deactivated == that.deactivated &&
+				id.equals(that.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(deactivated, id);
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetClass.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetClass.java
@@ -24,6 +24,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnorderedSelect;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -122,4 +123,23 @@ public class TargetClass extends NodeShape {
 		return new ExternalTypeFilterNode(shaclSailConnection, targetClass, parent, 0, true);
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		TargetClass that = (TargetClass) o;
+		return targetClass.equals(that.targetClass);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), targetClass);
+	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetNode.java
@@ -24,6 +24,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.SetFilterNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -104,4 +105,23 @@ public class TargetNode extends NodeShape {
 		return new LoggingNode(new SetFilterNode(targetNodeSet, parent, 0, true), "targetNode filter");
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		TargetNode that = (TargetNode) o;
+		return targetNodeSet.equals(that.targetNodeSet);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), targetNodeSet);
+	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetObjectsOf.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetObjectsOf.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.Select;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnorderedSelect;
 
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -110,4 +111,23 @@ public class TargetObjectsOf extends NodeShape {
 				ExternalFilterByPredicate.On.Object);
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		TargetObjectsOf that = (TargetObjectsOf) o;
+		return targetObjectsOf.equals(that.targetObjectsOf);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), targetObjectsOf);
+	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetSubjectsOf.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetSubjectsOf.java
@@ -22,6 +22,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.Select;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnorderedSelect;
 
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -107,4 +108,23 @@ public class TargetSubjectsOf extends NodeShape {
 				ExternalFilterByPredicate.On.Subject);
 	}
 
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		TargetSubjectsOf that = (TargetSubjectsOf) o;
+		return targetSubjectsOf.equals(that.targetSubjectsOf);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), targetSubjectsOf);
+	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/UniqueLangPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/UniqueLangPropertyShape.java
@@ -25,6 +25,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
+
 /**
  * @author Håvard Ottestad
  */
@@ -97,5 +99,25 @@ public class UniqueLangPropertyShape extends PathPropertyShape {
 	@Override
 	public SourceConstraintComponent getSourceConstraintComponent() {
 		return SourceConstraintComponent.UniqueLangConstraintComponent;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		UniqueLangPropertyShape that = (UniqueLangPropertyShape) o;
+		return uniqueLang == that.uniqueLang;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), uniqueLang);
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1290 .

Briefly describe the changes proposed in this PR:

* compare node shapes so not all are run when only some are changed
* 
* 
