### PR TITLE
Issues/1388 validate files that do not fit in memory

### DIFF
--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLServiceEvaluationTest.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLServiceEvaluationTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.query.parser.sparql;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -505,7 +506,7 @@ public class SPARQLServiceEvaluationTest extends TestCase {
 	private String readQueryString(String queryResource) throws RepositoryException, IOException {
 		InputStream stream = SPARQLServiceEvaluationTest.class.getResourceAsStream(queryResource);
 		try {
-			return IOUtil.readString(new InputStreamReader(stream, "UTF-8"));
+			return IOUtil.readString(new InputStreamReader(stream, StandardCharsets.UTF_8));
 		} finally {
 			stream.close();
 		}

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/EncodeForUri.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/function/string/EncodeForUri.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.query.algebra.evaluation.function.string;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
@@ -64,29 +65,24 @@ public class EncodeForUri implements Function {
 				buf.append(c);
 			} else {
 				// use UTF-8 hex encoding for character.
-				try {
-					byte[] utf8 = Character.toString(c).getBytes("UTF-8");
+				byte[] utf8 = Character.toString(c).getBytes(StandardCharsets.UTF_8);
 
-					for (byte b : utf8) {
-						// Escape character
-						buf.append('%');
+				for (byte b : utf8) {
+					// Escape character
+					buf.append('%');
 
-						char cb = (char) (b & 0xFF);
+					char cb = (char) (b & 0xFF);
 
-						String hexVal = Integer.toHexString(cb).toUpperCase();
+					String hexVal = Integer.toHexString(cb).toUpperCase();
 
-						// Ensure use of two characters
-						if (hexVal.length() == 1) {
-							buf.append('0');
-						}
-
-						buf.append(hexVal);
+					// Ensure use of two characters
+					if (hexVal.length() == 1) {
+						buf.append('0');
 					}
 
-				} catch (UnsupportedEncodingException e) {
-					// UTF-8 is always supported
-					throw new RuntimeException(e);
+					buf.append(hexVal);
 				}
+
 			}
 		}
 

--- a/memory/src/main/java/org/eclipse/rdf4j/sail/memory/FileIO.java
+++ b/memory/src/main/java/org/eclipse/rdf4j/sail/memory/FileIO.java
@@ -21,6 +21,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -92,9 +93,9 @@ class FileIO {
 
 	private final ValueFactory vf;
 
-	private final CharsetEncoder charsetEncoder = Charset.forName("UTF-8").newEncoder();
+	private final CharsetEncoder charsetEncoder = StandardCharsets.UTF_8.newEncoder();
 
-	private final CharsetDecoder charsetDecoder = Charset.forName("UTF-8").newDecoder();
+	private final CharsetDecoder charsetDecoder = StandardCharsets.UTF_8.newDecoder();
 
 	private int formatVersion;
 

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStore.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.nativerdf;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.common.concurrent.locks.Lock;
@@ -172,7 +173,7 @@ public class ValueStore extends AbstractValueFactory {
 	 */
 	public NativeValue getValue(int id) throws IOException {
 		// Check value cache
-		Integer cacheID = new Integer(id);
+		Integer cacheID = id;
 		NativeValue resultValue = valueCache.get(cacheID);
 
 		if (resultValue == null) {
@@ -310,7 +311,7 @@ public class ValueStore extends AbstractValueFactory {
 		nv.setInternalID(id, revision);
 
 		// Update cache
-		valueIDCache.put(nv, new Integer(id));
+		valueIDCache.put(nv, id);
 
 		return id;
 	}
@@ -338,9 +339,7 @@ public class ValueStore extends AbstractValueFactory {
 				writeLock.release();
 			}
 		} catch (InterruptedException e) {
-			IOException ioe = new IOException("Failed to acquire write lock");
-			ioe.initCause(e);
-			throw ioe;
+			throw new IOException("Failed to acquire write lock", e);
 		}
 	}
 
@@ -443,7 +442,7 @@ public class ValueStore extends AbstractValueFactory {
 		}
 
 		// Get local name in UTF-8
-		byte[] localNameData = uri.getLocalName().getBytes("UTF-8");
+		byte[] localNameData = uri.getLocalName().getBytes(StandardCharsets.UTF_8);
 
 		// Combine parts in a single byte array
 		byte[] uriData = new byte[5 + localNameData.length];
@@ -455,7 +454,7 @@ public class ValueStore extends AbstractValueFactory {
 	}
 
 	private byte[] bnode2data(BNode bNode, boolean create) throws IOException {
-		byte[] idData = bNode.getID().getBytes("UTF-8");
+		byte[] idData = bNode.getID().getBytes(StandardCharsets.UTF_8);
 
 		byte[] bNodeData = new byte[1 + idData.length];
 		bNodeData[0] = BNODE_VALUE;
@@ -495,12 +494,12 @@ public class ValueStore extends AbstractValueFactory {
 		byte[] langData = null;
 		int langDataLength = 0;
 		if (lang.isPresent()) {
-			langData = lang.get().getBytes("UTF-8");
+			langData = lang.get().getBytes(StandardCharsets.UTF_8);
 			langDataLength = langData.length;
 		}
 
 		// Get label in UTF-8
-		byte[] labelData = label.getBytes("UTF-8");
+		byte[] labelData = label.getBytes(StandardCharsets.UTF_8);
 
 		// Combine parts in a single byte array
 		byte[] literalData = new byte[6 + langDataLength + labelData.length];
@@ -536,13 +535,13 @@ public class ValueStore extends AbstractValueFactory {
 		int nsID = ByteArrayUtil.getInt(data, 1);
 		String namespace = getNamespace(nsID);
 
-		String localName = new String(data, 5, data.length - 5, "UTF-8");
+		String localName = new String(data, 5, data.length - 5, StandardCharsets.UTF_8);
 
 		return new NativeIRI(revision, namespace, localName, id);
 	}
 
 	private NativeBNode data2bnode(int id, byte[] data) throws IOException {
-		String nodeID = new String(data, 1, data.length - 1, "UTF-8");
+		String nodeID = new String(data, 1, data.length - 1, StandardCharsets.UTF_8);
 		return new NativeBNode(revision, nodeID, id);
 	}
 
@@ -558,11 +557,11 @@ public class ValueStore extends AbstractValueFactory {
 		String lang = null;
 		int langLength = data[5];
 		if (langLength > 0) {
-			lang = new String(data, 6, langLength, "UTF-8");
+			lang = new String(data, 6, langLength, StandardCharsets.UTF_8);
 		}
 
 		// Get label
-		String label = new String(data, 6 + langLength, data.length - 6 - langLength, "UTF-8");
+		String label = new String(data, 6 + langLength, data.length - 6 - langLength, StandardCharsets.UTF_8);
 
 		if (lang != null) {
 			return new NativeLiteral(revision, label, lang, id);
@@ -574,16 +573,16 @@ public class ValueStore extends AbstractValueFactory {
 	}
 
 	private String data2namespace(byte[] data) throws UnsupportedEncodingException {
-		return new String(data, "UTF-8");
+		return new String(data, StandardCharsets.UTF_8);
 	}
 
 	private int getNamespaceID(String namespace, boolean create) throws IOException {
 		Integer cacheID = namespaceIDCache.get(namespace);
 		if (cacheID != null) {
-			return cacheID.intValue();
+			return cacheID;
 		}
 
-		byte[] namespaceData = namespace.getBytes("UTF-8");
+		byte[] namespaceData = namespace.getBytes(StandardCharsets.UTF_8);
 
 		int id;
 		if (create) {
@@ -593,14 +592,14 @@ public class ValueStore extends AbstractValueFactory {
 		}
 
 		if (id != -1) {
-			namespaceIDCache.put(namespace, new Integer(id));
+			namespaceIDCache.put(namespace, id);
 		}
 
 		return id;
 	}
 
 	private String getNamespace(int id) throws IOException {
-		Integer cacheID = new Integer(id);
+		Integer cacheID = id;
 		String namespace = namespaceCache.get(cacheID);
 
 		if (namespace == null) {

--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
@@ -69,6 +69,8 @@ public abstract class AbstractSailConnection implements SailConnection {
 
 	private volatile boolean txnPrepared;
 
+	private int addedCount = 0;
+
 	/**
 	 * Lock used to give the {@link #close()} method exclusive access to a connection.
 	 * <ul>
@@ -431,8 +433,6 @@ public abstract class AbstractSailConnection implements SailConnection {
 			connectionLock.readLock().unlock();
 		}
 	}
-
-	int addedCount = 0;
 
 	@Override
 	public final void addStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {

--- a/sail-base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
+++ b/sail-base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
@@ -504,6 +504,7 @@ public abstract class SailSourceConnection extends NotifyingSailConnectionBase
 			add(subj, pred, obj, datasets.get(op), explicitSinks.get(op), contexts);
 		}
 		addStatementInternal(subj, pred, obj, contexts);
+
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/AndPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/AndPropertyShape.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnionNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
 import org.slf4j.Logger;
@@ -44,7 +45,7 @@ public class AndPropertyShape extends PropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ClassPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/ClassPropertyShape.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.InnerJoin;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.ModifyTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Select;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Sort;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
@@ -55,7 +56,7 @@ public class ClassPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 
 		if (deactivated) {
 			return null;
@@ -67,14 +68,16 @@ public class ClassPropertyShape extends PathPropertyShape {
 			PlanNode planNode;
 
 			if (path == null) {
-				planNode = new ModifyTuple(overrideTargetNode, t -> {
+				planNode = new ModifyTuple(overrideTargetNode.getPlanNode(), t -> {
 					t.line.add(t.line.get(0));
 					return t;
 				});
 
 			} else {
-				planNode = new LoggingNode(new BulkedExternalInnerJoin(overrideTargetNode, shaclSailConnection,
-						path.getQuery("?a", "?c", null), false), "");
+				planNode = new LoggingNode(
+						new BulkedExternalInnerJoin(overrideTargetNode.getPlanNode(), shaclSailConnection,
+								path.getQuery("?a", "?c", null), false),
+						"");
 			}
 
 			// filter by type against addedStatements, this is an optimization for when you add the type statement in
@@ -202,7 +205,7 @@ public class ClassPropertyShape extends PathPropertyShape {
 						new BulkedExternalInnerJoin(removedTypeStatements, shaclSailConnection, query, false), ""),
 						t -> {
 							List<Value> line = t.line;
-							t.line = new ArrayList<>();
+							t.line = new ArrayList<>(2);
 							t.line.add(line.get(2));
 							t.line.add(line.get(0));
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/DatatypePropertyShape.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.DatatypeFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ public class DatatypePropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/InPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/InPropertyShape.java
@@ -12,19 +12,16 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
-import org.eclipse.rdf4j.sail.shacl.planNodes.DatatypeFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.ValueInFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * @author Håvard Ottestad
@@ -45,7 +42,7 @@ public class InPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/LanguageInPropertyShape.java
@@ -15,11 +15,10 @@ import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LanguageInFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -42,7 +41,7 @@ public class LanguageInPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxCountPropertyShape.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.GroupByCount;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.MaxCountFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnBufferedPlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnionNode;
@@ -55,14 +56,16 @@ public class MaxCountPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}
 
 		if (overrideTargetNode != null) {
-			PlanNode bulkedExternalInnerJoin = new LoggingNode(new BulkedExternalInnerJoin(overrideTargetNode,
-					shaclSailConnection, path.getQuery("?a", "?c", null), false), "");
+			PlanNode bulkedExternalInnerJoin = new LoggingNode(
+					new BulkedExternalInnerJoin(overrideTargetNode.getPlanNode(),
+							shaclSailConnection, path.getQuery("?a", "?c", null), false),
+					"");
 			PlanNode groupByCount = new LoggingNode(new GroupByCount(bulkedExternalInnerJoin), "");
 
 			PlanNode directTupleFromFilter = new LoggingNode(

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxExclusivePropertyShape.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public class MaxExclusivePropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxInclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxInclusivePropertyShape.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public class MaxInclusivePropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MaxLengthPropertyShape.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.MaxLengthFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ public class MaxLengthPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinCountPropertyShape.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.GroupByCount;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.MinCountFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnBufferedPlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnionNode;
@@ -56,13 +57,13 @@ public class MinCountPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}
 
 		if (overrideTargetNode != null) {
-			PlanNode allStatements = new LoggingNode(new BulkedExternalLeftOuterJoin(overrideTargetNode,
+			PlanNode allStatements = new LoggingNode(new BulkedExternalLeftOuterJoin(overrideTargetNode.getPlanNode(),
 					shaclSailConnection, path.getQuery("?a", "?c", null), false), "");
 			PlanNode groupBy = new LoggingNode(new GroupByCount(allStatements), "");
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinExclusivePropertyShape.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public class MinExclusivePropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinInclusivePropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinInclusivePropertyShape.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LiteralComparatorFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ public class MinInclusivePropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/MinLengthPropertyShape.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.MinLengthFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ public class MinLengthPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/NodeKindPropertyShape.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.NodeKindFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +67,7 @@ public class NodeKindPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
@@ -73,9 +73,9 @@ public class OrPropertyShape extends PropertyShape {
 					.collect(Collectors.toList())));
 
 		} else {
-			if(shaclSailConnection.sail.isCacheSelectNodes()){
+			if (shaclSailConnection.sail.isCacheSelectNodes()) {
 				targetNodesToValidate = new BufferedSplitter(overrideTargetNode.getPlanNode());
-			}else {
+			} else {
 				targetNodesToValidate = overrideTargetNode;
 			}
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
@@ -20,6 +20,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.InnerJoin;
 import org.eclipse.rdf4j.sail.shacl.planNodes.IteratorData;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnionNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Unique;
@@ -51,7 +52,7 @@ public class OrPropertyShape extends PropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}
@@ -64,7 +65,7 @@ public class OrPropertyShape extends PropertyShape {
 				.filter(list -> !list.isEmpty())
 				.collect(Collectors.toList());
 
-		BufferedSplitter targetNodesToValidate;
+		PlanNodeProvider targetNodesToValidate;
 		if (overrideTargetNode == null) {
 			targetNodesToValidate = new BufferedSplitter(unionAll(initialPlanNodes.stream()
 					.flatMap(Collection::stream)
@@ -72,7 +73,7 @@ public class OrPropertyShape extends PropertyShape {
 					.collect(Collectors.toList())));
 
 		} else {
-			targetNodesToValidate = new BufferedSplitter(overrideTargetNode);
+			targetNodesToValidate = overrideTargetNode;
 		}
 
 		List<List<PlanNode>> plannodes = or
@@ -84,7 +85,7 @@ public class OrPropertyShape extends PropertyShape {
 								return shape.getPlan(shaclSailConnection, nodeShape, false, null);
 							}
 							return shape.getPlan(shaclSailConnection, nodeShape, false,
-									new LoggingNode(targetNodesToValidate.getPlanNode(), ""));
+									targetNodesToValidate);
 						})
 						.filter(Objects::nonNull)
 						.collect(Collectors.toList()))

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/OrPropertyShape.java
@@ -73,7 +73,11 @@ public class OrPropertyShape extends PropertyShape {
 					.collect(Collectors.toList())));
 
 		} else {
-			targetNodesToValidate = overrideTargetNode;
+			if(shaclSailConnection.sail.isCacheSelectNodes()){
+				targetNodesToValidate = new BufferedSplitter(overrideTargetNode.getPlanNode());
+			}else {
+				targetNodesToValidate = overrideTargetNode;
+			}
 		}
 
 		List<List<PlanNode>> plannodes = or

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PathPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PathPropertyShape.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Sort;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnorderedSelect;
 
@@ -44,7 +45,7 @@ public class PathPropertyShape extends PropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		return shaclSailConnection.getCachedNodeFor(new Sort(new UnorderedSelect(shaclSailConnection, null,
 				(IRI) path.getId(), null, UnorderedSelect.OutputPattern.SubjectObject)));
 	}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PatternPropertyShape.java
@@ -14,6 +14,7 @@ import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EnrichWithShape;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PatternFilter;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,7 @@ public class PatternPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PlanGenerator.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PlanGenerator.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.shacl.AST;
 
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 
 import java.util.List;
 
@@ -19,7 +20,7 @@ import java.util.List;
 public interface PlanGenerator {
 
 	PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode);
+			PlanNodeProvider overrideTargetNode);
 
 	PlanNode getPlanAddedStatements(ShaclSailConnection shaclSailConnection, NodeShape nodeShape,
 			PlaneNodeWrapper planeNodeWrapper);

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/PropertyShape.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.sail.memory.MemoryStoreConnection;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.SourceConstraintComponent;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +50,7 @@ public class PropertyShape implements PlanGenerator, RequiresEvalutation {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		throw new IllegalStateException("Should never get here!!!");
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/StandardisedPlanHelper.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/StandardisedPlanHelper.java
@@ -16,6 +16,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.InnerJoin;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.ModifyTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnBufferedPlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnionNode;
 
@@ -26,19 +27,21 @@ public class StandardisedPlanHelper {
 	}
 
 	static public PlanNode getGenericSingleObjectPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape,
-			FilterAttacher filterAttacher, PathPropertyShape pathPropertyShape, PlanNode overrideTargetNode) {
+			FilterAttacher filterAttacher, PathPropertyShape pathPropertyShape, PlanNodeProvider overrideTargetNode) {
 		if (overrideTargetNode != null) {
 
 			PlanNode planNode;
 
 			if (pathPropertyShape.path == null) {
-				planNode = new ModifyTuple(overrideTargetNode, t -> {
+				planNode = new ModifyTuple(overrideTargetNode.getPlanNode(), t -> {
 					t.line.add(t.line.get(0));
 					return t;
 				});
 			} else {
-				planNode = new LoggingNode(new BulkedExternalInnerJoin(overrideTargetNode, shaclSailConnection,
-						pathPropertyShape.path.getQuery("?a", "?c", null), false), "");
+				planNode = new LoggingNode(
+						new BulkedExternalInnerJoin(overrideTargetNode.getPlanNode(), shaclSailConnection,
+								pathPropertyShape.path.getQuery("?a", "?c", null), false),
+						"");
 			}
 
 			return new LoggingNode(filterAttacher.attachFilter(planNode).getFalseNode(UnBufferedPlanNode.class),

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetClass.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetClass.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.planNodes.ExternalTypeFilterNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Select;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Sort;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
@@ -46,7 +47,7 @@ public class TargetClass extends NodeShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		PlanNode parent = shaclSailConnection.getCachedNodeFor(new Select(shaclSailConnection,
 				getQuery("?a", "?c", shaclSailConnection.getRdfsSubClassOfReasoner()), "*"));
 		return new TrimTuple(new LoggingNode(parent, ""), 0, 1);

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetNode.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.sail.shacl.RdfsSubClassOfReasoner;
 import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Select;
 import org.eclipse.rdf4j.sail.shacl.planNodes.SetFilterNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
@@ -44,7 +45,7 @@ public class TargetNode extends NodeShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		PlanNode parent = shaclSailConnection.getCachedNodeFor(new Select(shaclSailConnection,
 				getQuery("?a", "?c", shaclSailConnection.getRdfsSubClassOfReasoner()), "*"));
 		return new Unique(new TrimTuple(new LoggingNode(parent, ""), 0, 1));

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetObjectsOf.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetObjectsOf.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.planNodes.ExternalFilterByPredicate;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Select;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnorderedSelect;
@@ -43,7 +44,7 @@ public class TargetObjectsOf extends NodeShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		PlanNode parent = shaclSailConnection
 				.getCachedNodeFor(new Select(shaclSailConnection, getQuery("?a", "?c", null), "?a", "?b1", "?c"));
 		return new TrimTuple(new LoggingNode(parent, ""), 0, 1);

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetSubjectsOf.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/TargetSubjectsOf.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 import org.eclipse.rdf4j.sail.shacl.planNodes.ExternalFilterByPredicate;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Select;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnorderedSelect;
@@ -42,7 +43,7 @@ public class TargetSubjectsOf extends NodeShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection connection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		PlanNode parent = connection.getCachedNodeFor(new Select(connection, getQuery("?a", "?c", null), "*"));
 		return new TrimTuple(new LoggingNode(parent, ""), 0, 1);
 	}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/UniqueLangPropertyShape.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/AST/UniqueLangPropertyShape.java
@@ -19,6 +19,7 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.InnerJoin;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.NonUniqueTargetLang;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
+import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNodeProvider;
 import org.eclipse.rdf4j.sail.shacl.planNodes.TrimTuple;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnBufferedPlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.UnionNode;
@@ -49,14 +50,16 @@ public class UniqueLangPropertyShape extends PathPropertyShape {
 
 	@Override
 	public PlanNode getPlan(ShaclSailConnection shaclSailConnection, NodeShape nodeShape, boolean printPlans,
-			PlanNode overrideTargetNode) {
+			PlanNodeProvider overrideTargetNode) {
 		if (deactivated) {
 			return null;
 		}
 
 		if (overrideTargetNode != null) {
-			PlanNode relevantTargetsWithPath = new LoggingNode(new BulkedExternalInnerJoin(overrideTargetNode,
-					shaclSailConnection, path.getQuery("?a", "?c", null), false), "");
+			PlanNode relevantTargetsWithPath = new LoggingNode(
+					new BulkedExternalInnerJoin(overrideTargetNode.getPlanNode(),
+							shaclSailConnection, path.getQuery("?a", "?c", null), false),
+					"");
 
 			PlanNode planNode = new NonUniqueTargetLang(relevantTargetsWithPath);
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -176,7 +177,7 @@ public class ShaclSail extends NotifyingSailWrapper {
 	}
 
 	private static String resourceAsString(String s) throws IOException {
-		return IOUtils.toString(ShaclSail.class.getClassLoader().getResourceAsStream(s), "UTF-8");
+		return IOUtils.toString(ShaclSail.class.getClassLoader().getResourceAsStream(s), StandardCharsets.UTF_8);
 	}
 
 	public ShaclSail(NotifyingSail baseSail) {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/AbstractBulkJoinPlanNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/AbstractBulkJoinPlanNode.java
@@ -42,7 +42,7 @@ abstract class AbstractBulkJoinPlanNode implements PlanNode {
 				connection.evaluate(parsedQuery.getTupleExpr(), parsedQuery.getDataset(), new MapBindingSet(), true))) {
 			stream
 					.map(Tuple::new)
-					.forEach(right::addFirst);
+					.forEachOrdered(right::addFirst);
 		}
 
 	}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BufferedSplitter.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BufferedSplitter.java
@@ -23,7 +23,7 @@ import java.util.List;
  *         parent iterator. This will potentially take a fair bit of memory, but maybe be useful for perfomance so that
  *         we don't query the underlying datastores for the same data multiple times.
  */
-public class BufferedSplitter {
+public class BufferedSplitter implements PlanNodeProvider {
 
 	PlanNode parent;
 	private List<Tuple> tuplesBuffer;
@@ -88,8 +88,9 @@ public class BufferedSplitter {
 
 			@Override
 			public void getPlanAsGraphvizDot(StringBuilder stringBuilder) {
-				if (printed)
+				if (printed) {
 					return;
+				}
 				printed = true;
 				stringBuilder.append(getId() + " [label=\"" + StringEscapeUtils.escapeJava(this.toString()) + "\"];")
 						.append("\n");
@@ -114,4 +115,5 @@ public class BufferedSplitter {
 		};
 
 	}
+
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
@@ -172,13 +172,15 @@ public class BulkedExternalInnerJoin extends AbstractBulkJoinPlanNode {
 					.append("\n");
 		}
 
-
-		if(skipBasedOnPreviousConnection){
+		if (skipBasedOnPreviousConnection) {
 			if (connection instanceof ShaclSailConnection) {
-				NotifyingSailConnection previousStateConnection = ((ShaclSailConnection) connection).getPreviousStateConnection();
+				NotifyingSailConnection previousStateConnection = ((ShaclSailConnection) connection)
+						.getPreviousStateConnection();
 
-				stringBuilder.append(System.identityHashCode(previousStateConnection) + " -> " + getId() + " [label=\"skip if not present\"]")
-					.append("\n");
+				stringBuilder
+						.append(System.identityHashCode(previousStateConnection) + " -> " + getId()
+								+ " [label=\"skip if not present\"]")
+						.append("\n");
 			}
 		}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalInnerJoin.java
@@ -14,9 +14,11 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserFactory;
 import org.eclipse.rdf4j.query.parser.QueryParserRegistry;
+import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.memory.MemoryStoreConnection;
+import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
 
 import java.util.ArrayDeque;
 
@@ -168,6 +170,16 @@ public class BulkedExternalInnerJoin extends AbstractBulkJoinPlanNode {
 		} else {
 			stringBuilder.append(System.identityHashCode(connection) + " -> " + getId() + " [label=\"right\"]")
 					.append("\n");
+		}
+
+
+		if(skipBasedOnPreviousConnection){
+			if (connection instanceof ShaclSailConnection) {
+				NotifyingSailConnection previousStateConnection = ((ShaclSailConnection) connection).getPreviousStateConnection();
+
+				stringBuilder.append(System.identityHashCode(previousStateConnection) + " -> " + getId() + " [label=\"skip if not present\"]")
+					.append("\n");
+			}
 		}
 
 		leftNode.getPlanAsGraphvizDot(stringBuilder);

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalLeftOuterJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalLeftOuterJoin.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.query.impl.MapBindingSet;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserFactory;
 import org.eclipse.rdf4j.query.parser.QueryParserRegistry;
+import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.memory.MemoryStoreConnection;
@@ -169,6 +170,15 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 		} else {
 			stringBuilder.append(System.identityHashCode(connection) + " -> " + getId() + " [label=\"right\"]")
 					.append("\n");
+		}
+
+		if(skipBasedOnPreviousConnection){
+			if (connection instanceof ShaclSailConnection) {
+				NotifyingSailConnection previousStateConnection = ((ShaclSailConnection) connection).getPreviousStateConnection();
+
+				stringBuilder.append(System.identityHashCode(previousStateConnection) + " -> " + getId() + " [label=\"skip if not present\"]")
+					.append("\n");
+			}
 		}
 
 		stringBuilder.append(leftNode.getId() + " -> " + getId() + " [label=\"left\"]").append("\n");

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalLeftOuterJoin.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/BulkedExternalLeftOuterJoin.java
@@ -172,12 +172,15 @@ public class BulkedExternalLeftOuterJoin extends AbstractBulkJoinPlanNode {
 					.append("\n");
 		}
 
-		if(skipBasedOnPreviousConnection){
+		if (skipBasedOnPreviousConnection) {
 			if (connection instanceof ShaclSailConnection) {
-				NotifyingSailConnection previousStateConnection = ((ShaclSailConnection) connection).getPreviousStateConnection();
+				NotifyingSailConnection previousStateConnection = ((ShaclSailConnection) connection)
+						.getPreviousStateConnection();
 
-				stringBuilder.append(System.identityHashCode(previousStateConnection) + " -> " + getId() + " [label=\"skip if not present\"]")
-					.append("\n");
+				stringBuilder
+						.append(System.identityHashCode(previousStateConnection) + " -> " + getId()
+								+ " [label=\"skip if not present\"]")
+						.append("\n");
 			}
 		}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/DatatypeFilter.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/DatatypeFilter.java
@@ -34,6 +34,6 @@ public class DatatypeFilter extends FilterPlanNode {
 
 	@Override
 	public String toString() {
-		return "DatatypeFilter{" + "datatype=" + datatype + '}';
+		return "DatatypeFilter{" + "datatype=" + Formatter.prefix(datatype) + '}';
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalFilterByPredicate.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalFilterByPredicate.java
@@ -146,7 +146,7 @@ public class ExternalFilterByPredicate implements PlanNode {
 
 	@Override
 	public String toString() {
-		return "ExternalFilterByPredicate{" + "filterOnPredicates=" + Arrays.toString(filterOnPredicates.toArray())
+		return "ExternalFilterByPredicate{" + "filterOnPredicates=" + Arrays.toString(filterOnPredicates.stream().map(Formatter::prefix).toArray())
 				+ '}';
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalFilterByPredicate.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalFilterByPredicate.java
@@ -146,7 +146,8 @@ public class ExternalFilterByPredicate implements PlanNode {
 
 	@Override
 	public String toString() {
-		return "ExternalFilterByPredicate{" + "filterOnPredicates=" + Arrays.toString(filterOnPredicates.stream().map(Formatter::prefix).toArray())
+		return "ExternalFilterByPredicate{" + "filterOnPredicates="
+				+ Arrays.toString(filterOnPredicates.stream().map(Formatter::prefix).toArray())
 				+ '}';
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalTypeFilterNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalTypeFilterNode.java
@@ -138,7 +138,8 @@ public class ExternalTypeFilterNode implements PlanNode {
 
 	@Override
 	public String toString() {
-		return "ExternalTypeFilterNode{" + "filterOnType=" + Arrays.toString(filterOnType.stream().map(Formatter::prefix).toArray()) + '}';
+		return "ExternalTypeFilterNode{" + "filterOnType="
+				+ Arrays.toString(filterOnType.stream().map(Formatter::prefix).toArray()) + '}';
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalTypeFilterNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ExternalTypeFilterNode.java
@@ -138,7 +138,7 @@ public class ExternalTypeFilterNode implements PlanNode {
 
 	@Override
 	public String toString() {
-		return "ExternalTypeFilterNode{" + "filterOnType=" + Arrays.toString(filterOnType.toArray()) + '}';
+		return "ExternalTypeFilterNode{" + "filterOnType=" + Arrays.toString(filterOnType.stream().map(Formatter::prefix).toArray()) + '}';
 	}
 
 	@Override

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Formatter.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Formatter.java
@@ -1,7 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
@@ -18,7 +24,6 @@ public class Formatter {
 		if (in instanceof IRI) {
 
 			String namespace = ((IRI) in).getNamespace();
-
 
 			if (namespace.equals(RDF.NAMESPACE)) {
 				return in.toString().replace(RDF.NAMESPACE, RDF.PREFIX + ":");
@@ -39,7 +44,6 @@ public class Formatter {
 		}
 
 		return in.toString();
-
 
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Formatter.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Formatter.java
@@ -1,0 +1,46 @@
+package org.eclipse.rdf4j.sail.shacl.planNodes;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.SHACL;
+
+public class Formatter {
+
+	public static String prefix(Value in) {
+
+		if (in == null) {
+			return "null";
+		}
+
+		if (in instanceof IRI) {
+
+			String namespace = ((IRI) in).getNamespace();
+
+
+			if (namespace.equals(RDF.NAMESPACE)) {
+				return in.toString().replace(RDF.NAMESPACE, RDF.PREFIX + ":");
+			}
+			if (namespace.equals(RDFS.NAMESPACE)) {
+				return in.toString().replace(RDFS.NAMESPACE, RDFS.PREFIX + ":");
+			}
+			if (namespace.equals(SHACL.NAMESPACE)) {
+				return in.toString().replace(SHACL.NAMESPACE, SHACL.PREFIX + ":");
+			}
+			if (namespace.equals("http://example.com/ns#")) {
+				return in.toString().replace("http://example.com/ns#", "ex:");
+			}
+			if (namespace.equals("http://www.w3.org/2001/XMLSchema#")) {
+				return in.toString().replace("http://www.w3.org/2001/XMLSchema#", "xsd:");
+			}
+
+		}
+
+		return in.toString();
+
+
+	}
+
+}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/PlanNodeProvider.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/PlanNodeProvider.java
@@ -1,0 +1,7 @@
+package org.eclipse.rdf4j.sail.shacl.planNodes;
+
+public interface PlanNodeProvider {
+
+	PlanNode getPlanNode();
+
+}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/SetFilterNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/SetFilterNode.java
@@ -108,7 +108,8 @@ public class SetFilterNode implements PlanNode {
 
 	@Override
 	public String toString() {
-		return "SetFilterNode{" + "targetNodeList=" + Arrays.toString(targetNodeList.stream().map(Formatter::prefix).toArray()) + ", index=" + index
+		return "SetFilterNode{" + "targetNodeList="
+				+ Arrays.toString(targetNodeList.stream().map(Formatter::prefix).toArray()) + ", index=" + index
 				+ ", returnValid=" + returnValid + '}';
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/SetFilterNode.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/SetFilterNode.java
@@ -108,7 +108,7 @@ public class SetFilterNode implements PlanNode {
 
 	@Override
 	public String toString() {
-		return "SetFilterNode{" + "targetNodeList=" + Arrays.toString(targetNodeList.toArray()) + ", index=" + index
+		return "SetFilterNode{" + "targetNodeList=" + Arrays.toString(targetNodeList.stream().map(Formatter::prefix).toArray()) + ", index=" + index
 				+ ", returnValid=" + returnValid + '}';
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Tuple.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Tuple.java
@@ -9,6 +9,7 @@
 package org.eclipse.rdf4j.sail.shacl.planNodes;
 
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Binding;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.algebra.evaluation.util.ValueComparator;
 import org.eclipse.rdf4j.sail.shacl.AST.PropertyShape;
@@ -16,10 +17,12 @@ import org.eclipse.rdf4j.sail.shacl.AST.PropertyShape;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * @author Heshan Jayasinghe, Håvard Mikkelsen Ottestad
@@ -51,7 +54,11 @@ public class Tuple implements Comparable<Tuple> {
 	}
 
 	public Tuple(BindingSet bindingset) {
-		bindingset.getBindingNames().stream().sorted().forEach(name -> line.add(bindingset.getValue(name)));
+
+		StreamSupport.stream(bindingset.spliterator(), false)
+				.sorted(Comparator.comparing(Binding::getName))
+				.map(Binding::getValue)
+				.forEachOrdered(value -> line.add(value));
 
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Tuple.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/Tuple.java
@@ -32,7 +32,7 @@ public class Tuple implements Comparable<Tuple> {
 
 	public List<Value> line = new ArrayList<>(3);
 
-	private ValueComparator valueComparator = new ValueComparator();
+	static final private ValueComparator valueComparator = new ValueComparator();
 
 	public Tuple(List<Value> list) {
 		line = list;

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnorderedSelect.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/UnorderedSelect.java
@@ -126,9 +126,9 @@ public class UnorderedSelect implements PlanNode {
 	@Override
 	public String toString() {
 		return "UnorderedSelect{" +
-				"subject=" + subject +
-				", predicate=" + predicate +
-				", object=" + object +
+				"subject=" + Formatter.prefix(subject) +
+				", predicate=" + Formatter.prefix(predicate) +
+				", object=" + Formatter.prefix(object) +
 				'}';
 	}
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ValueInFilter.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ValueInFilter.java
@@ -36,6 +36,7 @@ public class ValueInFilter extends FilterPlanNode {
 
 	@Override
 	public String toString() {
-		return "ValueInFilter{" + "valueSet=" + Arrays.toString(valueSet.stream().map(Formatter::prefix).toArray()) + '}';
+		return "ValueInFilter{" + "valueSet=" + Arrays.toString(valueSet.stream().map(Formatter::prefix).toArray())
+				+ '}';
 	}
 }

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ValueInFilter.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/planNodes/ValueInFilter.java
@@ -36,6 +36,6 @@ public class ValueInFilter extends FilterPlanNode {
 
 	@Override
 	public String toString() {
-		return "ValueInFilter{" + "valueSet=" + Arrays.toString(valueSet.toArray()) + '}';
+		return "ValueInFilter{" + "valueSet=" + Arrays.toString(valueSet.stream().map(Formatter::prefix).toArray()) + '}';
 	}
 }

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 import static junit.framework.TestCase.assertTrue;
 
@@ -79,7 +80,7 @@ public class ValidationReportTest {
 
 			connection.begin();
 			connection.prepareUpdate(IOUtils.toString(ValidationReportTest.class.getClassLoader()
-					.getResourceAsStream("test-cases/or/datatype/invalid/case1/query1.rq"), "utf-8")).execute();
+					.getResourceAsStream("test-cases/or/datatype/invalid/case1/query1.rq"), StandardCharsets.UTF_8)).execute();
 			connection.commit();
 
 		} catch (RepositoryException e) {

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ValidationReportTest.java
@@ -80,7 +80,8 @@ public class ValidationReportTest {
 
 			connection.begin();
 			connection.prepareUpdate(IOUtils.toString(ValidationReportTest.class.getClassLoader()
-					.getResourceAsStream("test-cases/or/datatype/invalid/case1/query1.rq"), StandardCharsets.UTF_8)).execute();
+					.getResourceAsStream("test-cases/or/datatype/invalid/case1/query1.rq"), StandardCharsets.UTF_8))
+					.execute();
 			connection.commit();
 
 		} catch (RepositoryException e) {

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexBenchmark.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/ComplexBenchmark.java
@@ -38,6 +38,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -60,10 +61,10 @@ public class ComplexBenchmark {
 		try {
 			transaction1 = IOUtils.toString(
 					ComplexBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/transaction1.qr"),
-					"utf-8");
+					StandardCharsets.UTF_8);
 			transaction2 = IOUtils.toString(
 					ComplexBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/transaction2.qr"),
-					"utf-8");
+					StandardCharsets.UTF_8);
 
 		} catch (IOException e) {
 			throw new RuntimeException();

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
@@ -49,8 +49,8 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 @Warmup(iterations = 5)
 @BenchmarkMode({ Mode.AverageTime })
-@Fork(value = 1, jvmArgs = { "-Xms64M", "-Xmx64M", "-XX:+UseParallelGC" })
-//@Fork(value = 1, jvmArgs = { "-Xms64M", "-Xmx64M", "-XX:+UseParallelGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=15s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Fork(value = 1, jvmArgs = { "-Xms45M", "-Xmx45M", "-XX:+UseSerialGC" })
+//@Fork(value = 1, jvmArgs = { "-Xms45M", "-Xmx45M", "-XX:+UseSerialGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=15s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
 @Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class NativeStoreBenchmark {

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
@@ -49,8 +49,8 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 @Warmup(iterations = 5)
 @BenchmarkMode({ Mode.AverageTime })
-//@Fork(value = 1, jvmArgs = { "-Xms64M", "-Xmx64M", "-XX:+UseParallelGC" })
-@Fork(value = 1, jvmArgs = {"-Xms128M", "-Xmx128M", "-XX:+UseParallelGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=15s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Fork(value = 1, jvmArgs = { "-Xms64M", "-Xmx64M", "-XX:+UseParallelGC" })
+//@Fork(value = 1, jvmArgs = { "-Xms64M", "-Xmx64M", "-XX:+UseParallelGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=15s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
 @Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class NativeStoreBenchmark {
@@ -171,7 +171,6 @@ public class NativeStoreBenchmark {
 
 	}
 
-
 	@Benchmark
 	public void nativeStore() throws IOException {
 
@@ -206,7 +205,7 @@ public class NativeStoreBenchmark {
 
 	}
 
-	//@Benchmark this should always run out of memory, as proof that we need the native store
+	// @Benchmark this should always run out of memory, as proof that we need the native store
 	public void memoryStore() throws IOException {
 
 		NotifyingSail shaclSail = new MemoryStore();
@@ -238,7 +237,7 @@ public class NativeStoreBenchmark {
 
 	private InputStream getFile(String s) {
 		return NativeStoreBenchmark.class.getClassLoader()
-			.getResourceAsStream(s);
+				.getResourceAsStream(s);
 	}
 
 }

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.shacl.benchmark;
+
+import ch.qos.logback.classic.Logger;
+import org.apache.commons.io.FileUtils;
+import org.assertj.core.util.Files;
+import org.eclipse.rdf4j.IsolationLevels;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.sail.NotifyingSail;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+import org.eclipse.rdf4j.sail.shacl.ShaclSailConnection;
+import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * @author Håvard Ottestad
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 20)
+@BenchmarkMode({Mode.AverageTime})
+@Fork(value = 1, jvmArgs = {"-Xms64M", "-Xmx64M", "-XX:+UseParallelGC"})
+//@Fork(value = 1, jvmArgs = {"-Xms128M", "-Xmx128M", "-XX:+UseParallelGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=15s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class NativeStoreBenchmark {
+
+	@Setup(Level.Iteration)
+	public void setUp() {
+		System.gc();
+		((Logger) LoggerFactory.getLogger(ShaclSailConnection.class.getName()))
+			.setLevel(ch.qos.logback.classic.Level.ERROR);
+		((Logger) LoggerFactory.getLogger(ShaclSail.class.getName())).setLevel(ch.qos.logback.classic.Level.ERROR);
+	}
+
+	@Benchmark
+	public void shaclNativeStore() throws IOException {
+
+		File file = Files.newTemporaryFolder();
+
+		ShaclSail shaclSail = new ShaclSail(new NativeStore(file,"spoc,ospc,psoc"));
+
+		shaclSail.setCacheSelectNodes(false);
+		shaclSail.setParallelValidation(false);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+		sailRepository.init();
+		shaclSail.disableValidation();
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			System.out.println("1");
+			connection.begin(IsolationLevels.NONE);
+			try (InputStream inputStream = NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/shacl.ttl")) {
+				connection.add(inputStream, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+			}
+			connection.commit();
+			System.out.println("2");
+
+			connection.begin(IsolationLevels.NONE);
+
+			try (InputStream inputStream = new BufferedInputStream(NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/generated.ttl"))) {
+				connection.add(inputStream, "", RDFFormat.TURTLE);
+			}
+			connection.commit();
+
+			System.out.println("3");
+
+		}
+		shaclSail.enableValidation();
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+
+			System.out.println("HERE");
+
+			connection.begin(IsolationLevels.NONE);
+			ValidationReport revalidate = ((ShaclSailConnection) connection.getSailConnection()).revalidate();
+			connection.commit();
+
+			if (!revalidate.conforms()) {
+				System.out.println("Data is invalid");
+				Rio.write(revalidate.asModel(), System.out, RDFFormat.TURTLE);
+			}
+
+		}
+
+		sailRepository.shutDown();
+
+		FileUtils.deleteDirectory(file);
+
+	}
+
+
+	@Benchmark
+	public void nativeStore() throws IOException {
+
+
+		File file = Files.newTemporaryFolder();
+
+		NotifyingSail shaclSail = new NativeStore(file);
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+		sailRepository.init();
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			connection.begin(IsolationLevels.NONE);
+
+			try (InputStream inputStream = NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/shacl.ttl")) {
+				connection.add(inputStream, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+			}
+			connection.commit();
+
+			connection.begin(IsolationLevels.NONE);
+
+			try (InputStream inputStream = new BufferedInputStream(NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/generated.ttl"))) {
+				connection.add(inputStream, "", RDFFormat.TURTLE);
+			}
+			connection.commit();
+
+
+		}
+
+		sailRepository.shutDown();
+
+		FileUtils.deleteDirectory(file);
+
+	}
+
+
+	@Benchmark
+	public void memoryStore() throws IOException {
+
+
+
+		NotifyingSail shaclSail = new MemoryStore();
+
+		SailRepository sailRepository = new SailRepository(shaclSail);
+		sailRepository.init();
+
+		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
+
+			connection.begin(IsolationLevels.NONE);
+
+			try (InputStream inputStream = NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/shacl.ttl")) {
+				connection.add(inputStream, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
+			}
+			connection.commit();
+
+			connection.begin(IsolationLevels.NONE);
+
+			try (InputStream inputStream = new BufferedInputStream(NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/generated.ttl"))) {
+				connection.add(inputStream, "", RDFFormat.TURTLE);
+			}
+			connection.commit();
+
+
+		}
+
+		sailRepository.shutDown();
+
+
+	}
+
+}

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/NativeStoreBenchmark.java
@@ -43,14 +43,13 @@ import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
-
 /**
  * @author Håvard Ottestad
  */
 @State(Scope.Benchmark)
 @Warmup(iterations = 20)
-@BenchmarkMode({Mode.AverageTime})
-@Fork(value = 1, jvmArgs = {"-Xms64M", "-Xmx64M", "-XX:+UseParallelGC"})
+@BenchmarkMode({ Mode.AverageTime })
+@Fork(value = 1, jvmArgs = { "-Xms64M", "-Xmx64M", "-XX:+UseParallelGC" })
 //@Fork(value = 1, jvmArgs = {"-Xms128M", "-Xmx128M", "-XX:+UseParallelGC", "-XX:+UnlockCommercialFeatures", "-XX:StartFlightRecording=delay=15s,duration=120s,filename=recording.jfr,settings=profile", "-XX:FlightRecorderOptions=samplethreads=true,stackdepth=1024", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints"})
 @Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -60,7 +59,7 @@ public class NativeStoreBenchmark {
 	public void setUp() {
 		System.gc();
 		((Logger) LoggerFactory.getLogger(ShaclSailConnection.class.getName()))
-			.setLevel(ch.qos.logback.classic.Level.ERROR);
+				.setLevel(ch.qos.logback.classic.Level.ERROR);
 		((Logger) LoggerFactory.getLogger(ShaclSail.class.getName())).setLevel(ch.qos.logback.classic.Level.ERROR);
 	}
 
@@ -69,7 +68,7 @@ public class NativeStoreBenchmark {
 
 		File file = Files.newTemporaryFolder();
 
-		ShaclSail shaclSail = new ShaclSail(new NativeStore(file,"spoc,ospc,psoc"));
+		ShaclSail shaclSail = new ShaclSail(new NativeStore(file, "spoc,ospc,psoc"));
 
 		shaclSail.setCacheSelectNodes(false);
 		shaclSail.setParallelValidation(false);
@@ -82,7 +81,8 @@ public class NativeStoreBenchmark {
 
 			System.out.println("1");
 			connection.begin(IsolationLevels.NONE);
-			try (InputStream inputStream = NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/shacl.ttl")) {
+			try (InputStream inputStream = NativeStoreBenchmark.class.getClassLoader()
+					.getResourceAsStream("complexBenchmark/shacl.ttl")) {
 				connection.add(inputStream, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			}
 			connection.commit();
@@ -90,7 +90,8 @@ public class NativeStoreBenchmark {
 
 			connection.begin(IsolationLevels.NONE);
 
-			try (InputStream inputStream = new BufferedInputStream(NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/generated.ttl"))) {
+			try (InputStream inputStream = new BufferedInputStream(NativeStoreBenchmark.class.getClassLoader()
+					.getResourceAsStream("complexBenchmark/generated.ttl"))) {
 				connection.add(inputStream, "", RDFFormat.TURTLE);
 			}
 			connection.commit();
@@ -101,7 +102,6 @@ public class NativeStoreBenchmark {
 		shaclSail.enableValidation();
 
 		try (SailRepositoryConnection connection = sailRepository.getConnection()) {
-
 
 			System.out.println("HERE");
 
@@ -122,10 +122,8 @@ public class NativeStoreBenchmark {
 
 	}
 
-
 	@Benchmark
 	public void nativeStore() throws IOException {
-
 
 		File file = Files.newTemporaryFolder();
 
@@ -138,18 +136,19 @@ public class NativeStoreBenchmark {
 
 			connection.begin(IsolationLevels.NONE);
 
-			try (InputStream inputStream = NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/shacl.ttl")) {
+			try (InputStream inputStream = NativeStoreBenchmark.class.getClassLoader()
+					.getResourceAsStream("complexBenchmark/shacl.ttl")) {
 				connection.add(inputStream, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			}
 			connection.commit();
 
 			connection.begin(IsolationLevels.NONE);
 
-			try (InputStream inputStream = new BufferedInputStream(NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/generated.ttl"))) {
+			try (InputStream inputStream = new BufferedInputStream(NativeStoreBenchmark.class.getClassLoader()
+					.getResourceAsStream("complexBenchmark/generated.ttl"))) {
 				connection.add(inputStream, "", RDFFormat.TURTLE);
 			}
 			connection.commit();
-
 
 		}
 
@@ -159,11 +158,8 @@ public class NativeStoreBenchmark {
 
 	}
 
-
 	@Benchmark
 	public void memoryStore() throws IOException {
-
-
 
 		NotifyingSail shaclSail = new MemoryStore();
 
@@ -174,23 +170,23 @@ public class NativeStoreBenchmark {
 
 			connection.begin(IsolationLevels.NONE);
 
-			try (InputStream inputStream = NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/shacl.ttl")) {
+			try (InputStream inputStream = NativeStoreBenchmark.class.getClassLoader()
+					.getResourceAsStream("complexBenchmark/shacl.ttl")) {
 				connection.add(inputStream, "", RDFFormat.TURTLE, RDF4J.SHACL_SHAPE_GRAPH);
 			}
 			connection.commit();
 
 			connection.begin(IsolationLevels.NONE);
 
-			try (InputStream inputStream = new BufferedInputStream(NativeStoreBenchmark.class.getClassLoader().getResourceAsStream("complexBenchmark/generated.ttl"))) {
+			try (InputStream inputStream = new BufferedInputStream(NativeStoreBenchmark.class.getClassLoader()
+					.getResourceAsStream("complexBenchmark/generated.ttl"))) {
 				connection.add(inputStream, "", RDFFormat.TURTLE);
 			}
 			connection.commit();
 
-
 		}
 
 		sailRepository.shutDown();
-
 
 	}
 

--- a/testsuites/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/geosparql/GeoSPARQLManifestTest.java
+++ b/testsuites/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/geosparql/GeoSPARQLManifestTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.query.algebra.geosparql;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.rdf4j.query.parser.sparql.manifest.SPARQLQueryTest;
 
@@ -21,7 +22,7 @@ public abstract class GeoSPARQLManifestTest {
 	public static Test suite(SPARQLQueryTest.Factory factory) throws Exception {
 		TestSuite suite = new TestSuite(factory.getClass().getName());
 		URL manifestUrl = GeoSPARQLManifestTest.class.getResource("/testcases-geosparql/manifest.txt");
-		BufferedReader reader = new BufferedReader(new InputStreamReader(manifestUrl.openStream(), "UTF-8"));
+		BufferedReader reader = new BufferedReader(new InputStreamReader(manifestUrl.openStream(), StandardCharsets.UTF_8));
 		String line;
 		while ((line = reader.readLine()) != null) {
 			URL url = new URL(manifestUrl, line);

--- a/testsuites/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/geosparql/GeoSPARQLManifestTest.java
+++ b/testsuites/geosparql/src/main/java/org/eclipse/rdf4j/query/algebra/geosparql/GeoSPARQLManifestTest.java
@@ -22,7 +22,8 @@ public abstract class GeoSPARQLManifestTest {
 	public static Test suite(SPARQLQueryTest.Factory factory) throws Exception {
 		TestSuite suite = new TestSuite(factory.getClass().getName());
 		URL manifestUrl = GeoSPARQLManifestTest.class.getResource("/testcases-geosparql/manifest.txt");
-		BufferedReader reader = new BufferedReader(new InputStreamReader(manifestUrl.openStream(), StandardCharsets.UTF_8));
+		BufferedReader reader = new BufferedReader(
+				new InputStreamReader(manifestUrl.openStream(), StandardCharsets.UTF_8));
 		String line;
 		while ((line = reader.readLine()) != null) {
 			URL url = new URL(manifestUrl, line);

--- a/testsuites/serql/src/main/java/org/eclipse/rdf4j/query/parser/serql/SeRQLParserTestCase.java
+++ b/testsuites/serql/src/main/java/org/eclipse/rdf4j/query/parser/serql/SeRQLParserTestCase.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.model.IRI;
@@ -87,7 +88,7 @@ public abstract class SeRQLParserTestCase extends TestCase {
 	protected void runTest() throws Exception {
 		// Read query from file
 		InputStream stream = url(queryFile).openStream();
-		String query = IOUtil.readString(new InputStreamReader(stream, "UTF-8"));
+		String query = IOUtil.readString(new InputStreamReader(stream, StandardCharsets.UTF_8));
 		stream.close();
 
 		try {

--- a/testsuites/serql/src/main/java/org/eclipse/rdf4j/query/parser/serql/SeRQLQueryTestCase.java
+++ b/testsuites/serql/src/main/java/org/eclipse/rdf4j/query/parser/serql/SeRQLQueryTestCase.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -240,7 +241,7 @@ public abstract class SeRQLQueryTestCase extends TestCase {
 	private String readQuery() throws IOException {
 		InputStream stream = url(queryFile).openStream();
 		try {
-			return IOUtil.readString(new InputStreamReader(stream, "UTF-8"));
+			return IOUtil.readString(new InputStreamReader(stream, StandardCharsets.UTF_8));
 		} finally {
 			stream.close();
 		}

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL11SyntaxTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQL11SyntaxTest.java
@@ -16,6 +16,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.JarURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -117,7 +118,7 @@ public abstract class SPARQL11SyntaxTest extends TestCase {
 	@Override
 	protected void runTest() throws Exception {
 		InputStream stream = new URL(queryFileURL).openStream();
-		String query = IOUtil.readString(new InputStreamReader(stream, "UTF-8"));
+		String query = IOUtil.readString(new InputStreamReader(stream, StandardCharsets.UTF_8));
 		stream.close();
 
 		try {

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQLQueryTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQLQueryTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -466,7 +467,7 @@ public abstract class SPARQLQueryTest extends TestCase {
 	protected final String readQueryString() throws IOException {
 		InputStream stream = new URL(queryFileURL).openStream();
 		try {
-			return IOUtil.readString(new InputStreamReader(stream, "UTF-8"));
+			return IOUtil.readString(new InputStreamReader(stream, StandardCharsets.UTF_8));
 		} finally {
 			stream.close();
 		}

--- a/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQLUpdateConformanceTest.java
+++ b/testsuites/sparql/src/main/java/org/eclipse/rdf4j/query/parser/sparql/manifest/SPARQLUpdateConformanceTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -253,7 +254,7 @@ public abstract class SPARQLUpdateConformanceTest extends TestCase {
 	private String readUpdateString() throws IOException {
 		InputStream stream = new URL(requestFileURL).openStream();
 		try {
-			return IOUtil.readString(new InputStreamReader(stream, "UTF-8"));
+			return IOUtil.readString(new InputStreamReader(stream, StandardCharsets.UTF_8));
 		} finally {
 			stream.close();
 		}


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1388 .

Briefly describe the changes proposed in this PR:

* clean up utf-8 in all code
* benchmark with large generated file, nativestore and memory restrictions
* fix for not being able to load a single big file in a single transaction into nativestore
* fixes in SHACL to be cache-less (eg. no caching needed anywhere)
