### PR TITLE
issues/1392 skip listener if base sail is empty

### DIFF
--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/RdfsSubClassOfReasoner.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/RdfsSubClassOfReasoner.java
@@ -14,6 +14,8 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,6 +28,8 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 public class RdfsSubClassOfReasoner {
+
+	private static final Logger logger = LoggerFactory.getLogger(RdfsSubClassOfReasoner.class);
 
 	private final Collection<Statement> subClassOfStatements = new ArrayList<>();
 	private final Collection<Resource> types = new ArrayList<>();
@@ -135,6 +139,11 @@ public class RdfsSubClassOfReasoner {
 	}
 
 	static RdfsSubClassOfReasoner createReasoner(ShaclSailConnection shaclSailConnection) {
+		long before = 0;
+		if (shaclSailConnection.sail.isPerformanceLogging()) {
+			before = System.currentTimeMillis();
+		}
+
 		RdfsSubClassOfReasoner rdfsSubClassOfReasoner = new RdfsSubClassOfReasoner();
 
 		try (Stream<? extends Statement> stream = Iterations
@@ -143,7 +152,14 @@ public class RdfsSubClassOfReasoner {
 		}
 
 		rdfsSubClassOfReasoner.calculateSubClassOf(rdfsSubClassOfReasoner.subClassOfStatements);
+		if (shaclSailConnection.sail.isPerformanceLogging()) {
+			logger.info("RdfsSubClassOfReasoner.createReasoner() took {} ms", System.currentTimeMillis() - before);
+		}
 		return rdfsSubClassOfReasoner;
+	}
+
+	public boolean isEmpty() {
+		return subClassOfStatements.isEmpty() && forwardChainCache.isEmpty() && backwardsChainCache.isEmpty();
 	}
 }
 

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -300,6 +300,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		selectNodeCache = null;
 		shapesModifiedInCurrentTransaction = false;
 		stamp = 0;
+		currentIsolationLevel = null;
 		if (sail.isPerformanceLogging()) {
 			logger.info("cleanup() took {} ms", System.currentTimeMillis() - before);
 		}

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -283,10 +283,13 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		connectionsToClose.forEach(SailConnection::close);
 		connectionsToClose = new ConcurrentLinkedQueue<>();
 
-		if (addedStatements != null && addedStatements != sail.getBaseSail()) {
-			addedStatements.shutDown();
+		if (addedStatements != null) {
+			if (addedStatements != sail.getBaseSail()) {
+				addedStatements.shutDown();
+			}
 			addedStatements = null;
 		}
+
 		if (removedStatements != null) {
 			removedStatements.shutDown();
 			removedStatements = null;
@@ -452,7 +455,6 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 							if (addedStatements != null && addedStatements != sail.getBaseSail()) {
 								addedStatements.shutDown();
-								addedStatements = null;
 							}
 
 							addedStatements = getNewMemorySail();

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -422,8 +422,8 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 			flush();
 
-			if (rdfsSubClassOfReasoner != null && rdfsSubClassOfReasoner.isEmpty() && sail.getBaseSail() instanceof MemoryStore
-					&& this.getIsolationLevel() == IsolationLevels.NONE) {
+			if ((rdfsSubClassOfReasoner == null || rdfsSubClassOfReasoner.isEmpty())
+					&& sail.getBaseSail() instanceof MemoryStore && this.getIsolationLevel() == IsolationLevels.NONE) {
 				addedStatements = (MemoryStore) sail.getBaseSail();
 				removedStatements = getNewMemorySail();
 			} else {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -422,7 +422,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 			flush();
 
-			if (rdfsSubClassOfReasoner.isEmpty() && sail.getBaseSail() instanceof MemoryStore
+			if (rdfsSubClassOfReasoner != null && rdfsSubClassOfReasoner.isEmpty() && sail.getBaseSail() instanceof MemoryStore
 					&& this.getIsolationLevel() == IsolationLevels.NONE) {
 				addedStatements = (MemoryStore) sail.getBaseSail();
 				removedStatements = getNewMemorySail();

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -55,6 +55,7 @@ import java.util.stream.Stream;
 
 /**
  * @author Heshan Jayasinghe
+ * @author Håvard Ottestad
  */
 public class ShaclSailConnection extends NotifyingSailConnectionWrapper implements SailConnectionListener {
 
@@ -95,6 +96,10 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 	ValueComparator valueComparator = new ValueComparator();
 
+	private boolean connectionListenerActive = false;
+
+	private IsolationLevel currentIsolationLevel = null;
+
 	ShaclSailConnection(ShaclSail sail, NotifyingSailConnection connection,
 			NotifyingSailConnection previousStateConnection, SailRepositoryConnection shapesRepoConnection) {
 		super(connection);
@@ -102,9 +107,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		this.shapesRepoConnection = shapesRepoConnection;
 		this.sail = sail;
 
-		if (sail.isValidationEnabled()) {
-			addConnectionListener(this);
-		}
+		setupConnectionListener();
 	}
 
 	public NotifyingSailConnection getPreviousStateConnection() {
@@ -130,7 +133,7 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 	@Override
 	public void begin(IsolationLevel level) throws SailException {
-
+		currentIsolationLevel = level;
 		assert addedStatements == null;
 		assert removedStatements == null;
 		assert connectionsToClose.size() == 0;
@@ -146,7 +149,20 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		}
 
 		stats.baseSailEmpty = !hasStatement(null, null, null, true);
+		if (stats.baseSailEmpty) {
+			removeConnectionListener(this);
+			connectionListenerActive = false;
+		} else {
+			setupConnectionListener();
+		}
 
+	}
+
+	private void setupConnectionListener() {
+		if (!connectionListenerActive && sail.isValidationEnabled()) {
+			addConnectionListener(this);
+
+		}
 	}
 
 	private MemoryStore getNewMemorySail() {
@@ -162,6 +178,10 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		if (!preparedHasRun) {
 			prepare();
 		}
+		long before = 0;
+		if (sail.isPerformanceLogging()) {
+			before = System.currentTimeMillis();
+		}
 		previousStateConnection.commit();
 		super.commit();
 		shapesRepoConnection.commit();
@@ -173,6 +193,9 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			sail.releaseExclusiveWriteLock(stamp);
 		}
 
+		if (sail.isPerformanceLogging()) {
+			logger.info("commit() excluding validation and cleanup took {} ms", System.currentTimeMillis() - before);
+		}
 		cleanup();
 	}
 
@@ -251,11 +274,16 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 	}
 
 	void cleanup() {
+		long before = 0;
+		if (sail.isPerformanceLogging()) {
+			before = System.currentTimeMillis();
+		}
+
 		logger.debug("Cleanup");
 		connectionsToClose.forEach(SailConnection::close);
 		connectionsToClose = new ConcurrentLinkedQueue<>();
 
-		if (addedStatements != null) {
+		if (addedStatements != null && addedStatements != sail.getBaseSail()) {
 			addedStatements.shutDown();
 			addedStatements = null;
 		}
@@ -272,6 +300,9 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		selectNodeCache = null;
 		shapesModifiedInCurrentTransaction = false;
 		stamp = 0;
+		if (sail.isPerformanceLogging()) {
+			logger.info("cleanup() took {} ms", System.currentTimeMillis() - before);
+		}
 	}
 
 	private List<NodeShape> refreshShapes() {
@@ -298,6 +329,11 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			validating = true;
 
 			fillAddedAndRemovedStatementRepositories();
+
+			long beforeValidation = 0;
+			if (sail.isPerformanceLogging()) {
+				beforeValidation = System.currentTimeMillis();
+			}
 
 			try {
 				Stream<PlanNode> planNodeStream = nodeShapes
@@ -356,65 +392,111 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			} finally {
 				connectionsToClose.forEach(SailConnection::close);
 				connectionsToClose = new ConcurrentLinkedQueue<>();
+				if (sail.isPerformanceLogging()) {
+					logger.info("Actual validation and generating plans took {} ms",
+							System.currentTimeMillis() - beforeValidation);
+				}
 			}
 		} finally {
 			validating = false;
 			rdfsSubClassOfReasoner = null;
+
 		}
 	}
 
 	void fillAddedAndRemovedStatementRepositories() {
 
+		long before = 0;
+		if (sail.isPerformanceLogging()) {
+			before = System.currentTimeMillis();
+		}
+
 		connectionsToClose.forEach(SailConnection::close);
 		connectionsToClose = new ConcurrentLinkedQueue<>();
 
-		Stream.of(addedStatementsSet, removedStatementsSet)
-				.parallel()
-				.forEach(set -> {
-					Set<Statement> otherSet;
-					MemoryStore repository;
-					if (set == addedStatementsSet) {
-						otherSet = removedStatementsSet;
+		if (stats.baseSailEmpty) {
 
-						if (addedStatements != null) {
-							addedStatements.shutDown();
-							addedStatements = null;
-						}
+			flush();
 
-						addedStatements = getNewMemorySail();
-						repository = addedStatements;
+			if (rdfsSubClassOfReasoner.isEmpty() && sail.getBaseSail() instanceof MemoryStore
+					&& this.getIsolationLevel() == IsolationLevels.NONE) {
+				addedStatements = (MemoryStore) sail.getBaseSail();
+				removedStatements = getNewMemorySail();
+			} else {
+				addedStatements = getNewMemorySail();
+				removedStatements = getNewMemorySail();
 
-						set.forEach(stats::added);
-
-					} else {
-						otherSet = addedStatementsSet;
-
-						if (removedStatements != null) {
-							removedStatements.shutDown();
-							removedStatements = null;
-						}
-
-						removedStatements = getNewMemorySail();
-						repository = removedStatements;
-
-						set.forEach(stats::removed);
-					}
-
-					try (SailConnection connection = repository.getConnection()) {
+				try (Stream<? extends Statement> stream = Iterations.stream(getStatements(null, null, null, false))) {
+					try (NotifyingSailConnection connection = addedStatements.getConnection()) {
 						connection.begin(IsolationLevels.NONE);
-						set.stream()
-								.filter(statement -> !otherSet.contains(statement))
+						stream
 								.flatMap(statement -> rdfsSubClassOfReasoner == null ? Stream.of(statement)
 										: rdfsSubClassOfReasoner.forwardChain(statement))
 								.forEach(statement -> connection.addStatement(statement.getSubject(),
 										statement.getPredicate(), statement.getObject(), statement.getContext()));
 						connection.commit();
 					}
+				}
+			}
 
-				});
+		} else {
 
+			Stream.of(addedStatementsSet, removedStatementsSet)
+					.parallel()
+					.forEach(set -> {
+						Set<Statement> otherSet;
+						MemoryStore repository;
+						if (set == addedStatementsSet) {
+							otherSet = removedStatementsSet;
+
+							if (addedStatements != null && addedStatements != sail.getBaseSail()) {
+								addedStatements.shutDown();
+								addedStatements = null;
+							}
+
+							addedStatements = getNewMemorySail();
+							repository = addedStatements;
+
+							set.forEach(stats::added);
+
+						} else {
+							otherSet = addedStatementsSet;
+
+							if (removedStatements != null) {
+								removedStatements.shutDown();
+								removedStatements = null;
+							}
+
+							removedStatements = getNewMemorySail();
+							repository = removedStatements;
+
+							set.forEach(stats::removed);
+						}
+
+						try (SailConnection connection = repository.getConnection()) {
+							connection.begin(IsolationLevels.NONE);
+							set.stream()
+									.filter(statement -> !otherSet.contains(statement))
+									.flatMap(statement -> rdfsSubClassOfReasoner == null ? Stream.of(statement)
+											: rdfsSubClassOfReasoner.forwardChain(statement))
+									.forEach(statement -> connection.addStatement(statement.getSubject(),
+											statement.getPredicate(), statement.getObject(), statement.getContext()));
+							connection.commit();
+						}
+
+					});
+
+		}
 		selectNodeCache = new HashMap<>();
 
+		if (sail.isPerformanceLogging()) {
+			logger.info("fillAddedAndRemovedStatementRepositories() took {} ms", System.currentTimeMillis() - before);
+		}
+
+	}
+
+	private IsolationLevel getIsolationLevel() {
+		return currentIsolationLevel;
 	}
 
 	@Override
@@ -434,6 +516,10 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		long readStamp = 0;
 
 		try {
+			long before = 0;
+			if (sail.isPerformanceLogging()) {
+				before = System.currentTimeMillis();
+			}
 			if (!sail.holdsWriteLock(stamp)) {
 				readStamp = sail.readlock();
 			}
@@ -447,8 +533,11 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 			// we don't support revalidation of all data when changing the shacl shapes,
 			// so no need to check if the shapes have changed
 			if (addedStatementsSet.isEmpty() && removedStatementsSet.isEmpty() && !shapesModifiedInCurrentTransaction) {
-				logger.debug("Nothing has changed, nothing to validate.");
-				return;
+				boolean currentBaseSailEmpty = !hasStatement(null, null, null, false);
+				if (!(stats.baseSailEmpty && !currentBaseSailEmpty)) {
+					logger.debug("Nothing has changed, nothing to validate.");
+					return;
+				}
 			}
 
 			if (shapesModifiedInCurrentTransaction && addedStatementsSet.isEmpty() && removedStatementsSet.isEmpty()) {
@@ -465,6 +554,11 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 			List<Tuple> invalidTuples = validate(nodeShapesAfterRefresh, shapesModifiedInCurrentTransaction);
 			boolean valid = invalidTuples.isEmpty();
+
+			if (sail.isPerformanceLogging()) {
+				logger.info("prepare() including validation excluding locking and super.prepare() took {} ms",
+						System.currentTimeMillis() - before);
+			}
 
 			if (!valid) {
 				throw new ShaclSailValidationException(invalidTuples);

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/PrepareCommitTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/PrepareCommitTest.java
@@ -30,6 +30,12 @@ public class PrepareCommitTest {
 		ShaclSail shaclSail = Utils.getInitializedShaclSail("shacl.ttl");
 
 		try (NotifyingSailConnection connection = shaclSail.getConnection()) {
+			// due to optimizations in the ShaclSail, changes after prepare has run will only be detected if there is
+			// data in the base sail already!
+			connection.begin();
+			connection.addStatement(RDFS.RESOURCE, RDFS.LABEL, SimpleValueFactory.getInstance().createLiteral("label"));
+			connection.commit();
+
 			connection.begin();
 			connection.addStatement(RDFS.RESOURCE, RDFS.SUBCLASSOF, RDFS.RESOURCE);
 			connection.prepare();


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1392 .

Briefly describe the changes proposed in this PR:

* Skip using a listener if the base sail is empty, and instead get added statements from base sail at end of transaction
* Skip getting statements at end of transaction if the isolation level is NONE, base sail is a memory store and there is no need for RDFS reasoning => so just use base sail as the added statements store directly
* more performance logging to help debug performance issues
