### PR TITLE
Issues/1396 improve benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ guidelines](https://github.com/eclipse/rdf4j/blob/master/.github/CONTRIBUTING.md
 The short version:
 
 1. Digitally sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php). You can do this by logging into the [Eclipse projects forge](http://www.eclipse.org/contribute/cla); click on "Eclipse Contributor Agreement"; and Complete the form. Be sure to use the same email address when you register for the account that you intend to use on Git commit records. See the [ECA FAQ](https://www.eclipse.org/legal/ecafaq.php) for more info. 
-2. Create an issue in the [issue tracker](https://github.com/eclipse/rdf4j/issues) that describes your improvement, new feature, or bug fix.
-3. Fork the GitHub repository.
-4. Create a new branch (starting from master) for your changes. 
-5. Make your changes on this branch. Apply the [RDF4J code formatting guidelines](https://github.com/eclipse/rdf4j-storage/blob/master/.github/CONTRIBUTING.md#code-formatting). Don't forget to include unit tests.
-6. **sign off** every commit (using the `-s` flag).
-7. Run `mvn verify` from the project root to make sure all tests succeed (both your own new ones, and existing).
-8. Use meaningful commit messages and include the issue number in each commit message.
-9. Once your fix is complete, put it up for review by opening a Pull Request against the master branch in the central Github repository.
+1. Create an issue in the [issue tracker](https://github.com/eclipse/rdf4j/issues) that describes your improvement, new feature, or bug fix.
+1. Fork the GitHub repository.
+1. Create a new branch (starting from master) for your changes. 
+1. Make your changes on this branch. Apply the [RDF4J code formatting guidelines](https://github.com/eclipse/rdf4j-storage/blob/master/.github/CONTRIBUTING.md#code-formatting). Don't forget to include unit tests.
+1. **sign off** every commit (using the `-s` flag).
+1. Run `mvn formatter:format` to format your code.
+1. Run `mvn verify` from the project root to make sure all tests succeed (both your own new ones, and existing).
+1. Use meaningful commit messages and include the issue number in each commit message.
+1. Once your fix is complete, put it up for review by opening a Pull Request against the master branch in the central Github repository.
 
 These steps are explained in more detail in the [Contributor
 guidelines](https://github.com/eclipse/rdf4j-storage/blob/master/.github/CONTRIBUTING.md).


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1396 .

Briefly describe the changes proposed in this PR:

* created a big benchmark for when optimisations for empty sail can not be utilised
* 
* 
