### PR TITLE
init optional in Sail and SailRepository 

### DIFF
--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/LuceneSail.java
@@ -512,14 +512,17 @@ public class LuceneSail extends NotifyingSailWrapper {
 			SailRepository repo = new SailRepository(new NotifyingSailWrapper(getBaseSail()) {
 
 				@Override
+				public void init() {
+					// don't re-initialize the Sail when we initialize the repo
+				}
+
+				@Override
 				public void shutDown() {
 					// don't shutdown the underlying sail
 					// when we shutdown the repo.
 				}
 			});
-			try ( // repo.initialize(); we don't need to initialize, that should be done
-					// already by others
-					SailRepositoryConnection connection = repo.getConnection()) {
+			try (SailRepositoryConnection connection = repo.getConnection()) {
 				TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SPARQL, reindexQuery);
 				TupleQueryResult res = query.evaluate();
 				Resource current = null;

--- a/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
+++ b/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryStoreTest.java
@@ -23,7 +23,6 @@ public class MemoryStoreTest extends RDFNotifyingStoreTest {
 	@Override
 	protected NotifyingSail createSail() throws SailException {
 		NotifyingSail sail = new MemoryStore();
-		sail.init();
 		return sail;
 	}
 }

--- a/repository-sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepository.java
+++ b/repository-sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepository.java
@@ -175,6 +175,9 @@ public class SailRepository extends AbstractRepository implements FederatedServi
 	@Override
 	public boolean isWritable() throws RepositoryException {
 		try {
+			if (!isInitialized()) {
+				init();
+			}
 			return sail.isWritable();
 		} catch (SailException e) {
 			throw new RepositoryException("Unable to determine writable status of Sail", e);
@@ -183,11 +186,17 @@ public class SailRepository extends AbstractRepository implements FederatedServi
 
 	@Override
 	public ValueFactory getValueFactory() {
+		if (!isInitialized()) {
+			init();
+		}
 		return sail.getValueFactory();
 	}
 
 	@Override
 	public SailRepositoryConnection getConnection() throws RepositoryException {
+		if (!isInitialized()) {
+			init();
+		}
 		try {
 			return new SailRepositoryConnection(this, sail.getConnection());
 		} catch (SailException e) {

--- a/repository-sail/src/test/java/org/eclipse/rdf4j/repository/sail/TestProxyRepository.java
+++ b/repository-sail/src/test/java/org/eclipse/rdf4j/repository/sail/TestProxyRepository.java
@@ -48,11 +48,6 @@ public class TestProxyRepository {
 		repository.shutDown();
 	}
 
-	@Test(expected = IllegalStateException.class)
-	public final void testDisallowAccessBeforeInitialize() throws RepositoryException {
-		repository.getConnection();
-	}
-
 	@Test
 	public final void testProperInitialization() throws RepositoryException {
 		assertThat(repository.getDataDir()).isEqualTo(dataDir.getRoot());
@@ -63,13 +58,6 @@ public class TestProxyRepository {
 		try (RepositoryConnection connection = repository.getConnection()) {
 			assertThat(connection).isInstanceOf(SailRepositoryConnection.class);
 		}
-	}
-
-	@Test(expected = IllegalStateException.class)
-	public final void testNoAccessAfterShutdown() throws RepositoryException {
-		repository.initialize();
-		repository.shutDown();
-		repository.getConnection();
 	}
 
 	@Test

--- a/sail-api/pom.xml
+++ b/sail-api/pom.xml
@@ -58,6 +58,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>

--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/Sail.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/Sail.java
@@ -42,8 +42,7 @@ public interface Sail {
 	 * Initializes the Sail. Care should be taken that required initialization parameters have been set before this
 	 * method is called. Please consult the specific Sail implementation for information about the relevant parameters.
 	 * 
-	 * @throws SailException         If the Sail could not be initialized.
-	 * @throws IllegalStateException If the Sail has already been initialized.
+	 * @throws SailException If the Sail could not be initialized.
 	 * @deprecated Use {{@link #init()} instead.
 	 */
 	@Deprecated
@@ -53,8 +52,7 @@ public interface Sail {
 	 * Initializes the Sail. Care should be taken that required initialization parameters have been set before this
 	 * method is called. Please consult the specific Sail implementation for information about the relevant parameters.
 	 * 
-	 * @throws SailException         If the Sail could not be initialized.
-	 * @throws IllegalStateException If the Sail has already been initialized.
+	 * @throws SailException If the Sail could not be initialized.
 	 * 
 	 * @since 2.5
 	 */

--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
@@ -180,10 +180,8 @@ public abstract class AbstractSail implements Sail {
 	public void init() throws SailException {
 		initializationLock.writeLock().lock();
 		try {
-			logger.trace("is initialized: {}", isInitialized());
 			if (isInitialized()) {
-				throw new IllegalStateException(
-						"Sail has already been intialized. Ensure this Sail is being used via a Repository.");
+				return; // skip silently 
 			}
 
 			initializeInternal();

--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
@@ -181,7 +181,7 @@ public abstract class AbstractSail implements Sail {
 		initializationLock.writeLock().lock();
 		try {
 			if (isInitialized()) {
-				return; // skip silently 
+				return; // skip silently
 			}
 
 			initializeInternal();

--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSail.java
@@ -266,12 +266,11 @@ public abstract class AbstractSail implements Sail {
 
 	@Override
 	public SailConnection getConnection() throws SailException {
+		if (!isInitialized()) {
+			init();
+		}
 		initializationLock.readLock().lock();
 		try {
-			if (!isInitialized()) {
-				throw new IllegalStateException("Sail is not initialized or has been shut down");
-			}
-
 			SailConnection connection = getConnectionInternal();
 
 			Throwable stackTrace = debugEnabled() ? new Throwable() : null;

--- a/sail-api/src/test/java/org/eclipse/rdf4j/sail/RDFStoreTest.java
+++ b/sail-api/src/test/java/org/eclipse/rdf4j/sail/RDFStoreTest.java
@@ -133,12 +133,11 @@ public abstract class RDFStoreTest {
 	 *---------*/
 
 	/**
-	 * Gets an instance of the Sail that should be tested. The returned repository should already have been initialized.
+	 * Gets an instance of the Sail that should be tested.
 	 * 
-	 * @return an initialized Sail.
-	 * @throws SailException If the initialization of the repository failed.
+	 * @return a Sail.
 	 */
-	protected abstract Sail createSail() throws SailException;
+	protected abstract Sail createSail();
 
 	@Before
 	public void setUp() throws Exception {

--- a/sail-api/src/test/java/org/eclipse/rdf4j/sail/helpers/AbstractSailTest.java
+++ b/sail-api/src/test/java/org/eclipse/rdf4j/sail/helpers/AbstractSailTest.java
@@ -75,11 +75,13 @@ public class AbstractSailTest {
 		assertThat(conn).isEqualTo(connDouble);
 	}
 
-	@Test(expected = IllegalStateException.class)
 	public void testExplicitInitTwice() {
 		assertThat(subject.isInitialized()).isFalse();
 		subject.init();
 		subject.init();
+		SailConnection conn = subject.getConnection();
+		assertThat(subject.isInitialized()).isTrue();
+		assertThat(conn).isEqualTo(connDouble);
 	}
 
 }

--- a/sail-api/src/test/java/org/eclipse/rdf4j/sail/helpers/AbstractSailTest.java
+++ b/sail-api/src/test/java/org/eclipse/rdf4j/sail/helpers/AbstractSailTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.SailException;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AbstractSail}.
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class AbstractSailTest {
+
+	AbstractSail subject;
+
+	SailConnection connDouble = mock(SailConnection.class);
+
+	@Before
+	public void setUp() throws Exception {
+
+		subject = new AbstractSail() {
+
+			@Override
+			public boolean isWritable() throws SailException {
+				return false;
+			}
+
+			@Override
+			public ValueFactory getValueFactory() {
+				return SimpleValueFactory.getInstance();
+			}
+
+			@Override
+			protected void shutDownInternal() throws SailException {
+				// TODO Auto-generated method stub
+
+			}
+
+			@Override
+			protected SailConnection getConnectionInternal() throws SailException {
+				return connDouble;
+			}
+
+		};
+	}
+
+	@Test
+	public void testAutoInitOnConnection() {
+		assertThat(subject.isInitialized()).isFalse();
+		SailConnection conn = subject.getConnection();
+		assertThat(subject.isInitialized()).isTrue();
+		assertThat(conn).isEqualTo(connDouble);
+	}
+
+	@Test
+	public void testExplicitInitBeforeConnection() {
+		assertThat(subject.isInitialized()).isFalse();
+		subject.init();
+		SailConnection conn = subject.getConnection();
+		assertThat(subject.isInitialized()).isTrue();
+		assertThat(conn).isEqualTo(connDouble);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testExplicitInitTwice() {
+		assertThat(subject.isInitialized()).isFalse();
+		subject.init();
+		subject.init();
+	}
+
+}

--- a/sail-api/src/test/java/org/eclipse/rdf4j/sail/helpers/AbstractSailTest.java
+++ b/sail-api/src/test/java/org/eclipse/rdf4j/sail/helpers/AbstractSailTest.java
@@ -8,7 +8,13 @@
 package org.eclipse.rdf4j.sail.helpers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -26,8 +32,6 @@ import org.junit.Test;
 public class AbstractSailTest {
 
 	AbstractSail subject;
-
-	SailConnection connDouble = mock(SailConnection.class);
 
 	@Before
 	public void setUp() throws Exception {
@@ -52,6 +56,11 @@ public class AbstractSailTest {
 
 			@Override
 			protected SailConnection getConnectionInternal() throws SailException {
+				SailConnection connDouble = mock(SailConnection.class);
+				doAnswer(f -> {
+					subject.connectionClosed(connDouble);
+					return null;
+				}).when(connDouble).close();
 				return connDouble;
 			}
 
@@ -63,7 +72,6 @@ public class AbstractSailTest {
 		assertThat(subject.isInitialized()).isFalse();
 		SailConnection conn = subject.getConnection();
 		assertThat(subject.isInitialized()).isTrue();
-		assertThat(conn).isEqualTo(connDouble);
 	}
 
 	@Test
@@ -72,16 +80,69 @@ public class AbstractSailTest {
 		subject.init();
 		SailConnection conn = subject.getConnection();
 		assertThat(subject.isInitialized()).isTrue();
-		assertThat(conn).isEqualTo(connDouble);
 	}
 
+	@Test
 	public void testExplicitInitTwice() {
 		assertThat(subject.isInitialized()).isFalse();
 		subject.init();
 		subject.init();
 		SailConnection conn = subject.getConnection();
 		assertThat(subject.isInitialized()).isTrue();
-		assertThat(conn).isEqualTo(connDouble);
+	}
+
+	@Test
+	public void testConcurrentAutoInit() throws Exception {
+		int count = 200;
+		CountDownLatch latch = new CountDownLatch(count);
+
+		for (int i = 0; i < count; i++) {
+			new Thread(new SailGetConnectionTask(subject, latch)).start();
+		}
+
+		if (!latch.await(30, TimeUnit.SECONDS)) {
+			fail("possible deadlock detected");
+		}
+	}
+
+	class SailGetConnectionTask implements Runnable {
+
+		private final AbstractSail sail;
+		private CountDownLatch connectionObtained;
+
+		public SailGetConnectionTask(AbstractSail sail, CountDownLatch connectionObtained) {
+			this.sail = sail;
+			this.connectionObtained = connectionObtained;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * 
+		 * @see java.lang.Runnable#run()
+		 */
+		@Override
+		public void run() {
+			try {
+				Thread.sleep(new Random().nextInt(1000));
+				if ((new Random().nextInt() & 1) == 0) {
+					sail.init(); // 50% of our runs do an explicit init
+				}
+				try (SailConnection conn = sail.getConnection()) {
+					Thread.sleep(10);
+				}
+				if (new Random().nextInt(4) == 1) {
+					sail.shutDown(); // roughly one in four do a shutdown follow by another get connection
+					try (SailConnection conn = sail.getConnection()) {
+						Thread.sleep(10);
+					}
+				}
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			} finally {
+				this.connectionObtained.countDown();
+			}
+		}
+
 	}
 
 }


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1223 .

Briefly describe the changes proposed in this PR:

* updated SailRepository to conform to modify Repository API contract
* made Sail.init() optional in the same way
* added unit test for Abstract Sail and fixed various implementations
