### PR TITLE
GH-1280 add QueryOptimizerPipeline

### DIFF
--- a/evaluation/pom.xml
+++ b/evaluation/pom.xml
@@ -69,7 +69,11 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.mapdb</groupId>
 			<artifactId>mapdb</artifactId>
@@ -77,11 +81,6 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 	<build>

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategy.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategy.java
@@ -7,11 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
-import java.util.List;
-
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.Service;

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategy.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategy.java
@@ -7,8 +7,11 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
+import java.util.List;
+
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.algebra.Service;
@@ -16,6 +19,7 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.ValueExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedService;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
 import org.eclipse.rdf4j.repository.sparql.federation.SPARQLFederatedService;
 
 /**
@@ -37,6 +41,28 @@ public interface EvaluationStrategy extends FederatedServiceResolver {
 	 */
 	@Override
 	public FederatedService getService(String serviceUrl) throws QueryEvaluationException;
+
+	/**
+	 * Set the {@link QueryOptimizerPipeline} to use for optimizing any incoming queries.
+	 * 
+	 * @param pipeline the {@link QueryOptimizerPipeline}.
+	 * @see #optimize(TupleExpr, EvaluationStatistics, BindingSet)
+	 * @since 3.0
+	 */
+	public void setOptimizerPipeline(QueryOptimizerPipeline pipeline);
+
+	/**
+	 * Execute the {@link QueryOptimizerPipeline} on the given {@link TupleExpr} to optimize its execution plan.
+	 * 
+	 * @param expr                 the {@link TupleExpr} to optimize.
+	 * @param evaluationStatistics the {@link EvaluationStatistics} of the data source, to be used for query planning.
+	 * @param bindings             a-priori bindings supplied for the query, which can potentially be inlined.
+	 * @return the optimized {@link TupleExpr}.
+	 * @see #setOptimizerPipeline(QueryOptimizerPipeline)
+	 * @since 3.0
+	 */
+	public TupleExpr optimize(TupleExpr expr, EvaluationStatistics evaluationStatistics,
+			BindingSet bindings);
 
 	/**
 	 * Evaluates the tuple expression against the supplied triple source with the specified set of variable bindings as

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/EvaluationStrategyFactory.java
@@ -7,7 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation;
 
+import java.util.Optional;
+
 import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
 
 /**
  * Factory for {@link EvaluationStrategy}s.
@@ -32,13 +35,30 @@ public interface EvaluationStrategyFactory {
 	long getQuerySolutionCacheThreshold();
 
 	/**
+	 * Set a {@link QueryOptimizerPipeline} to be used for query execution planning by the {@link EvaluationStrategy}.
+	 * 
+	 * @param pipeline a {@link QueryOptimizerPipeline}
+	 */
+	void setOptimizerPipeline(QueryOptimizerPipeline pipeline);
+
+	/**
+	 * Get the {@link QueryOptimizerPipeline} that this factory will inject into the {@link EvaluationStrategy}, if any.
+	 * If no {@link QueryOptimizerPipeline} is defined, the {@link EvaluationStrategy} itself determines the pipeline.
+	 * 
+	 * @return a {@link QueryOptimizerPipeline}, or {@link Optional#empty()} if no pipeline is set on this factory.
+	 */
+	Optional<QueryOptimizerPipeline> getOptimizerPipeline();
+
+	/**
 	 * Returns the {@link EvaluationStrategy} to use to evaluate queries for the given {@link Dataset} and
 	 * {@link TripleSource}.
 	 * 
-	 * @param dataset      the DataSet to evaluate queries against.
-	 * @param tripleSource the TripleSource to evaluate queries against.
+	 * @param dataset              the DataSet to evaluate queries against.
+	 * @param tripleSource         the TripleSource to evaluate queries against.
+	 * @param EvaluationStatistics the store evaluation statistics to use for query optimization.
 	 * @return an EvaluationStrategy.
 	 */
-	EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource);
+	EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
+			EvaluationStatistics evaluationStatistics);
 
 }

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizer.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizer.java
@@ -13,10 +13,11 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 
 /**
- * Interface used by {@link StrictEvaluationStrategy} prior to evalutating the query.
+ * Interface used by {@link EvaluationStrategy}s to optimize the {@link TupleExpr} prior to evaluating the query.
  * 
  * @author James Leigh
  * @author Arjohn Kampman
+ * @see QueryOptimizerPipeline
  */
 public interface QueryOptimizer {
 

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizer.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizer.java
@@ -10,7 +10,6 @@ package org.eclipse.rdf4j.query.algebra.evaluation;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
-import org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategy;
 
 /**
  * Interface used by {@link EvaluationStrategy}s to optimize the {@link TupleExpr} prior to evaluating the query.

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizerPipeline.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/QueryOptimizerPipeline.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation;
+
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+
+/**
+ * A pipeline of {@link QueryOptimizer}s that, when executed in order on a {@link TupleExpr}, convert that
+ * {@link TupleExpr} to a more optimal query execution plan.
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public interface QueryOptimizerPipeline {
+
+	/**
+	 * Get the optimizers that make up this pipeline.
+	 * 
+	 * @return an {@link Iterable} of {@link QueryOptimizer}s
+	 */
+	Iterable<QueryOptimizer> getOptimizers();
+}

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/AbstractEvaluationStrategyFactory.java
@@ -7,7 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
+import java.util.Optional;
+
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline;
 
 /**
  * Abstract base class for {@link ExtendedEvaluationStrategy}.
@@ -18,6 +21,8 @@ public abstract class AbstractEvaluationStrategyFactory implements EvaluationStr
 
 	private long querySolutionCacheThreshold;
 
+	private QueryOptimizerPipeline pipeline;
+
 	@Override
 	public void setQuerySolutionCacheThreshold(long threshold) {
 		this.querySolutionCacheThreshold = threshold;
@@ -26,6 +31,16 @@ public abstract class AbstractEvaluationStrategyFactory implements EvaluationStr
 	@Override
 	public long getQuerySolutionCacheThreshold() {
 		return querySolutionCacheThreshold;
+	}
+
+	@Override
+	public void setOptimizerPipeline(QueryOptimizerPipeline pipeline) {
+		this.pipeline = pipeline;
+	}
+
+	@Override
+	public Optional<QueryOptimizerPipeline> getOptimizerPipeline() {
+		return Optional.ofNullable(pipeline);
 	}
 
 }

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategy.java
@@ -30,8 +30,9 @@ import org.eclipse.rdf4j.query.algebra.evaluation.util.XMLDatatypeMathUtil;
 public class ExtendedEvaluationStrategy extends TupleFunctionEvaluationStrategy {
 
 	public ExtendedEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
-			FederatedServiceResolver serviceResolver, long iterationCacheSyncThreshold) {
-		super(tripleSource, dataset, serviceResolver, iterationCacheSyncThreshold);
+			FederatedServiceResolver serviceResolver, long iterationCacheSyncThreshold,
+			EvaluationStatistics evaluationStatistics) {
+		super(tripleSource, dataset, serviceResolver, iterationCacheSyncThreshold, evaluationStatistics);
 	}
 
 	@Override
@@ -40,7 +41,7 @@ public class ExtendedEvaluationStrategy extends TupleFunctionEvaluationStrategy 
 		Value leftVal = evaluate(node.getLeftArg(), bindings);
 		Value rightVal = evaluate(node.getRightArg(), bindings);
 
-		// return result of non-strict comparison.
+		// return result of non-strict comparisson.
 		return BooleanLiteral.valueOf(QueryEvaluationUtil.compare(leftVal, rightVal, node.getOperator(), false));
 	}
 

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategyFactory.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExtendedEvaluationStrategyFactory.java
@@ -36,8 +36,10 @@ public class ExtendedEvaluationStrategyFactory extends AbstractEvaluationStrateg
 	}
 
 	@Override
-	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		return new ExtendedEvaluationStrategy(tripleSource, dataset, serviceResolver, getQuerySolutionCacheThreshold());
+	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
+			EvaluationStatistics evaluationStatistics) {
+		return new ExtendedEvaluationStrategy(tripleSource, dataset, serviceResolver, getQuerySolutionCacheThreshold(),
+				evaluationStatistics);
 	}
 
 }

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SimpleEvaluationStrategy.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/SimpleEvaluationStrategy.java
@@ -43,7 +43,7 @@ public class SimpleEvaluationStrategy extends StrictEvaluationStrategy {
 	 */
 	public SimpleEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
 			FederatedServiceResolver serviceResolver, long iterationCacheSyncTreshold) {
-		super(tripleSource, dataset, serviceResolver, iterationCacheSyncTreshold);
+		super(tripleSource, dataset, serviceResolver, iterationCacheSyncTreshold, new EvaluationStatistics());
 	}
 
 }

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StandardQueryOptimizerPipeline.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+
+/**
+ * 
+ * A standard pipeline with the default {@link QueryOptimizer}s that will be used by {@link StrictEvaluationStrategy}
+ * and its subclasses, unless specifically overridden.
+ * 
+ * @author Jeen Broekstra
+ *
+ * @see EvaluationStrategyFactory#setOptimizerPipeline(QueryOptimizerPipeline)
+ */
+public class StandardQueryOptimizerPipeline implements QueryOptimizerPipeline {
+
+	private final EvaluationStatistics evaluationStatistics;
+	private final TripleSource tripleSource;
+	private final EvaluationStrategy strategy;
+
+	public StandardQueryOptimizerPipeline(EvaluationStrategy strategy, TripleSource tripleSource,
+			EvaluationStatistics evaluationStatistics) {
+		this.strategy = strategy;
+		this.tripleSource = tripleSource;
+		this.evaluationStatistics = evaluationStatistics;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline#getOptimizers()
+	 */
+	@Override
+	public Iterable<QueryOptimizer> getOptimizers() {
+		return Arrays.asList(
+				new BindingAssigner(),
+				new ConstantOptimizer(strategy),
+				new RegexAsStringFunctionOptimizer(tripleSource.getValueFactory()),
+				new CompareOptimizer(),
+				new ConjunctiveConstraintSplitter(),
+				new DisjunctiveConstraintOptimizer(),
+				new SameTermFilterOptimizer(),
+				new QueryModelNormalizer(),
+				new QueryJoinOptimizer(evaluationStatistics),
+				new IterativeEvaluationOptimizer(),
+				new FilterOptimizer(),
+				new OrderLimitOptimizer());
+	}
+
+}

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyFactory.java
@@ -36,7 +36,12 @@ public class StrictEvaluationStrategyFactory extends AbstractEvaluationStrategyF
 	}
 
 	@Override
-	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		return new StrictEvaluationStrategy(tripleSource, dataset, serviceResolver, getQuerySolutionCacheThreshold());
+	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
+			EvaluationStatistics evaluationStatistics) {
+		StrictEvaluationStrategy strategy = new StrictEvaluationStrategy(tripleSource, dataset, serviceResolver,
+				getQuerySolutionCacheThreshold(), evaluationStatistics);
+		getOptimizerPipeline().ifPresent(pipeline -> strategy.setOptimizerPipeline(pipeline));
+		return strategy;
 	}
+
 }

--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/TupleFunctionEvaluationStrategy.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/TupleFunctionEvaluationStrategy.java
@@ -41,19 +41,28 @@ public class TupleFunctionEvaluationStrategy extends StrictEvaluationStrategy {
 
 	public TupleFunctionEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
 			FederatedServiceResolver serviceResolver, long iterationCacheSyncThreshold) {
-		this(tripleSource, dataset, serviceResolver, TupleFunctionRegistry.getInstance(), iterationCacheSyncThreshold);
-	}
-
-	public TupleFunctionEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
-			FederatedServiceResolver serviceResolver, TupleFunctionRegistry tupleFuncRegistry,
-			long iterationCacheSyncThreshold) {
-		super(tripleSource, dataset, serviceResolver, iterationCacheSyncThreshold);
-		this.tupleFuncRegistry = tupleFuncRegistry;
+		this(tripleSource, dataset, serviceResolver, TupleFunctionRegistry.getInstance(), iterationCacheSyncThreshold,
+				new EvaluationStatistics());
 	}
 
 	public TupleFunctionEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
 			FederatedServiceResolver serviceResolver, TupleFunctionRegistry tupleFunctionRegistry) {
-		this(tripleSource, dataset, serviceResolver, tupleFunctionRegistry, 0);
+		this(tripleSource, dataset, serviceResolver, tupleFunctionRegistry, 0, new EvaluationStatistics());
+	}
+
+	public TupleFunctionEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
+			FederatedServiceResolver serviceResolver, TupleFunctionRegistry tupleFuncRegistry,
+			long iterationCacheSyncThreshold, EvaluationStatistics evaluationStatistics) {
+		super(tripleSource, dataset, serviceResolver, iterationCacheSyncThreshold, evaluationStatistics);
+		this.tupleFuncRegistry = tupleFuncRegistry;
+	}
+
+	public TupleFunctionEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
+			FederatedServiceResolver serviceResolver, long iterationCacheSyncThreshold,
+			EvaluationStatistics evaluationStatistics) {
+		this(tripleSource, dataset, serviceResolver, TupleFunctionRegistry.getInstance(), iterationCacheSyncThreshold,
+				evaluationStatistics);
+
 	}
 
 	@Override

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/StrictEvaluationStrategyTest.java
@@ -10,6 +10,11 @@ package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -17,8 +22,11 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline;
 import org.eclipse.rdf4j.query.parser.ParsedQuery;
 import org.eclipse.rdf4j.query.parser.QueryParserUtil;
 import org.junit.Before;
@@ -59,4 +67,25 @@ public class StrictEvaluationStrategyTest {
 		assertFalse(bs.hasBinding("y"));
 	}
 
+	@Test
+	public void testOptimize() throws Exception {
+
+		QueryOptimizer optimizer1 = mock(QueryOptimizer.class);
+		QueryOptimizer optimizer2 = mock(QueryOptimizer.class);
+
+		strategy.setOptimizerPipeline(new QueryOptimizerPipeline() {
+			@Override
+			public Iterable<QueryOptimizer> getOptimizers() {
+				return Arrays.asList(optimizer1, optimizer2);
+			}
+		});
+
+		TupleExpr expr = mock(TupleExpr.class);
+		EvaluationStatistics stats = new EvaluationStatistics();
+		BindingSet bindings = new QueryBindingSet();
+
+		strategy.optimize(expr, stats, bindings);
+		verify(optimizer1, times(1)).optimize(expr, null, bindings);
+		verify(optimizer2, times(1)).optimize(expr, null, bindings);
+	}
 }

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/OrderComparatorTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/util/OrderComparatorTest.java
@@ -24,8 +24,10 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.algebra.ValueExpr;
 import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
 import org.eclipse.rdf4j.query.algebra.evaluation.QueryBindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline;
 import org.eclipse.rdf4j.query.algebra.evaluation.ValueExprEvaluationException;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedService;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,6 +65,18 @@ public class OrderComparatorTest {
 		@Override
 		public FederatedService getService(String serviceUrl) throws QueryEvaluationException {
 			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void setOptimizerPipeline(QueryOptimizerPipeline pipeline) {
+			// TODO Auto-generated method stub
+
+		}
+
+		@Override
+		public TupleExpr optimize(TupleExpr expr, EvaluationStatistics evaluationStatistics, BindingSet bindings) {
+			// TODO Auto-generated method stub
+			return null;
 		}
 	}
 

--- a/sail-base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
+++ b/sail-base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
@@ -203,7 +203,8 @@ public abstract class SailSourceConnection extends NotifyingSailConnectionBase
 	}
 
 	protected EvaluationStrategy getEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
-		EvaluationStrategy evalStrat = evalStratFactory.createEvaluationStrategy(dataset, tripleSource);
+		EvaluationStrategy evalStrat = evalStratFactory.createEvaluationStrategy(dataset, tripleSource,
+				store.getEvaluationStatistics());
 		if (federatedServiceResolver != null && evalStrat instanceof FederatedServiceResolverClient) {
 			((FederatedServiceResolverClient) evalStrat).setFederatedServiceResolver(federatedServiceResolver);
 		}
@@ -238,21 +239,7 @@ public abstract class SailSourceConnection extends NotifyingSailConnectionBase
 			TripleSource tripleSource = new SailDatasetTripleSource(vf, rdfDataset);
 			EvaluationStrategy strategy = getEvaluationStrategy(dataset, tripleSource);
 
-			new BindingAssigner().optimize(tupleExpr, dataset, bindings);
-			new ConstantOptimizer(strategy).optimize(tupleExpr, dataset, bindings);
-			// The regex as string function optimizer works better if the constants are resolved
-			new RegexAsStringFunctionOptimizer(vf).optimize(tupleExpr, dataset, bindings);
-			new CompareOptimizer().optimize(tupleExpr, dataset, bindings);
-			new ConjunctiveConstraintSplitter().optimize(tupleExpr, dataset, bindings);
-			new DisjunctiveConstraintOptimizer().optimize(tupleExpr, dataset, bindings);
-			new SameTermFilterOptimizer().optimize(tupleExpr, dataset, bindings);
-			new QueryModelNormalizer().optimize(tupleExpr, dataset, bindings);
-			new QueryJoinOptimizer(store.getEvaluationStatistics()).optimize(tupleExpr, dataset, bindings);
-			// new SubSelectJoinOptimizer().optimize(tupleExpr, dataset,
-			// bindings);
-			new IterativeEvaluationOptimizer().optimize(tupleExpr, dataset, bindings);
-			new FilterOptimizer().optimize(tupleExpr, dataset, bindings);
-			new OrderLimitOptimizer().optimize(tupleExpr, dataset, bindings);
+			tupleExpr = strategy.optimize(tupleExpr, store.getEvaluationStatistics(), bindings);
 
 			logger.trace("Optimized query model:\n{}", tupleExpr);
 


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1280 .

Briefly describe the changes proposed in this PR:

* moved query optimization from Sail to EvaluationStrategy.
* Made QueryOptimizerPipeline an injectable interface for EvaluationStrategyFactory.

