### PR TITLE
GH-1404 ensure optimizer respects bag semantics of union

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizer.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizer.java
@@ -137,8 +137,6 @@ public class QueryModelNormalizer extends AbstractQueryModelVisitor<RuntimeExcep
 			union.replaceWith(rightArg);
 		} else if (rightArg instanceof EmptySet) {
 			union.replaceWith(leftArg);
-		} else if (leftArg instanceof SingletonSet && rightArg instanceof SingletonSet) {
-			union.replaceWith(leftArg);
 		}
 	}
 

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizerTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizerTest.java
@@ -1,0 +1,65 @@
+package org.eclipse.rdf4j.query.algebra.evaluation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.query.algebra.EmptySet;
+import org.eclipse.rdf4j.query.algebra.Projection;
+import org.eclipse.rdf4j.query.algebra.SingletonSet;
+import org.eclipse.rdf4j.query.algebra.Union;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class QueryModelNormalizerTest {
+
+	private static QueryModelNormalizer subject;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		subject = new QueryModelNormalizer();
+	}
+
+	@Test
+	public void testNormalizeUnionWithEmptyLeft() {
+		Projection p = new Projection();
+		Union union = new Union();
+		SingletonSet s = new SingletonSet();
+		union.setLeftArg(new EmptySet());
+		union.setRightArg(s);
+		p.setArg(union);
+
+		subject.meet(union);
+
+		assertThat(p.getArg()).isEqualTo(s);
+	}
+
+	@Test
+	public void testNormalizeUnionWithEmptyRight() {
+		Projection p = new Projection();
+		Union union = new Union();
+		SingletonSet s = new SingletonSet();
+		union.setRightArg(new EmptySet());
+		union.setLeftArg(s);
+		p.setArg(union);
+
+		subject.meet(union);
+
+		assertThat(p.getArg()).isEqualTo(s);
+	}
+
+	/**
+	 * @see https://github.com/eclipse/rdf4j/issues/1404
+	 */
+	@Test
+	public void testNormalizeUnionWithTwoSingletons() {
+		Projection p = new Projection();
+		Union union = new Union();
+		union.setRightArg(new SingletonSet());
+		union.setLeftArg(new SingletonSet());
+		p.setArg(union);
+
+		subject.meet(union);
+
+		assertThat(p.getArg()).isEqualTo(union);
+	}
+
+}

--- a/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizerTest.java
+++ b/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/QueryModelNormalizerTest.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
 package org.eclipse.rdf4j.query.algebra.evaluation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1404 .

Briefly describe the changes proposed in this PR:

* QueryModelNormalizer should not simplify union of two singletons to a single singleton
* added regression test.
