### PR TITLE
Issues/1413 dummy data in tests

### DIFF
--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -12,6 +12,7 @@ import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.IsolationLevels;
 import org.eclipse.rdf4j.common.io.IOUtil;
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -167,7 +168,7 @@ abstract public class AbstractShaclTest {
 	}
 
 	static void runTestCase(String shaclPath, String dataPath, ExpectedResult expectedResult,
-			IsolationLevel isolationLevel) throws Exception {
+			IsolationLevel isolationLevel, boolean preloadWithDummyData) throws Exception {
 
 		if (!dataPath.endsWith("/")) {
 			dataPath = dataPath + "/";
@@ -186,6 +187,17 @@ abstract public class AbstractShaclTest {
 
 		boolean exception = false;
 		boolean ran = false;
+
+		if (preloadWithDummyData) {
+			try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
+				connection.begin(isolationLevel);
+				ValueFactory vf = connection.getValueFactory();
+				connection.add(vf.createBNode(), vf.createIRI("http://example.com/jkhsdfiu3r2y9fjr3u0"),
+						vf.createLiteral("auto-generated!"), vf.createBNode());
+				connection.commit();
+			}
+
+		}
 
 		for (int j = 0; j < 100; j++) {
 

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/ShaclTest.java
@@ -25,7 +25,7 @@ public class ShaclTest extends AbstractShaclTest {
 
 	@Test
 	public void test() throws Exception {
-		runTestCase(testCasePath, path, expectedResult, isolationLevel);
+		runTestCase(testCasePath, path, expectedResult, isolationLevel, false);
 	}
 
 	@Test
@@ -36,6 +36,11 @@ public class ShaclTest extends AbstractShaclTest {
 	@Test
 	public void testRevalidation() throws Exception {
 		runTestCaseRevalidate(testCasePath, path, expectedResult, isolationLevel);
+	}
+
+	@Test
+	public void testNonEmpty() throws Exception {
+		runTestCase(testCasePath, path, expectedResult, isolationLevel, true);
 	}
 
 }


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1413 .

Briefly describe the changes proposed in this PR:

* new test method that preloads dummy data before running shacl transactions and validation
* 
* 
