### PR TITLE
eclipse/rdf4j#1425 only flush on removal if adds are pending

### DIFF
--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
@@ -405,6 +405,13 @@ public interface SailConnection extends AutoCloseable {
 	 */
 	public void clearNamespaces() throws SailException;
 
+	/**
+	 * Indicates if the Sail has any statement removal operations pending (not yet {@link #flush() flushed}) for the
+	 * current transaction.
+	 * 
+	 * @return true if any statement removal operations have not yet been flushed, false otherwise.
+	 * @see #flush()
+	 */
 	boolean pendingRemovals();
 
 }

--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/SailConnection.java
@@ -411,7 +411,9 @@ public interface SailConnection extends AutoCloseable {
 	 * 
 	 * @return true if any statement removal operations have not yet been flushed, false otherwise.
 	 * @see #flush()
+	 * @deprecated 
 	 */
+	@Deprecated
 	boolean pendingRemovals();
 
 }

--- a/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
+++ b/sail-api/src/main/java/org/eclipse/rdf4j/sail/helpers/AbstractSailConnection.java
@@ -439,7 +439,9 @@ public abstract class AbstractSailConnection implements SailConnection {
 
 	@Override
 	public final void removeStatements(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
-		flushPendingUpdates();
+		if (pendingAdds()) {
+			flushPendingUpdates();
+		}
 		removeStatement(null, subj, pred, obj, contexts);
 	}
 
@@ -663,6 +665,21 @@ public abstract class AbstractSailConnection implements SailConnection {
 			}
 		} finally {
 			connectionLock.readLock().unlock();
+		}
+	}
+
+	@Override
+	public boolean pendingRemovals() {
+		synchronized (removed) {
+			Collection<Statement> pending = removed.get(null);
+			return pending != null && !pending.isEmpty();
+		}
+	}
+
+	protected boolean pendingAdds() {
+		synchronized (added) {
+			Collection<Statement> pending = added.get(null);
+			return pending != null && !pending.isEmpty();
 		}
 	}
 

--- a/sail-base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
+++ b/sail-base/src/main/java/org/eclipse/rdf4j/sail/base/SailSourceConnection.java
@@ -186,29 +186,6 @@ public abstract class SailSourceConnection extends NotifyingSailConnectionBase
 		this.federatedServiceResolver = resolver;
 	}
 
-	@Override
-	public boolean pendingRemovals() {
-		return explicitSinks.values().stream().anyMatch(v -> {
-			if (v instanceof Changeset) {
-				return ((Changeset) v).hasDeprecated();
-			}
-			return false;
-		});
-
-	}
-
-	@Override
-	protected boolean pendingAdds() {
-		return explicitSinks.values().stream().anyMatch(v -> {
-			if (v instanceof Changeset) {
-				Changeset cs = ((Changeset) v);
-				return cs.getApproved() != null && !cs.getApproved().isEmpty();
-			}
-			return false;
-		});
-
-	}
-
 	protected EvaluationStrategy getEvaluationStrategy(Dataset dataset, TripleSource tripleSource) {
 		EvaluationStrategy evalStrat = evalStratFactory.createEvaluationStrategy(dataset, tripleSource);
 		if (federatedServiceResolver != null && evalStrat instanceof FederatedServiceResolverClient) {

--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSailConnection.java
@@ -147,7 +147,6 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 
 	@Override
 	public void commit() throws SailException {
-
 		if (!preparedHasRun) {
 			prepare();
 		}
@@ -155,7 +154,6 @@ public class ShaclSailConnection extends NotifyingSailConnectionWrapper implemen
 		super.commit();
 		shapesConnection.commit();
 		cleanup();
-
 	}
 
 	@Override

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TrackAddedStatementsTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TrackAddedStatementsTest.java
@@ -8,14 +8,18 @@
 
 package org.eclipse.rdf4j.sail.shacl;
 
+import static org.junit.Assert.fail;
+
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LoggingNode;
 import org.junit.Test;
 
@@ -150,14 +154,15 @@ public class TrackAddedStatementsTest {
 
 			try {
 				connection.commit();
-			} catch (Throwable e) {
-				System.out.println(e.getMessage());
+				fail("commit should have failed");
+			} catch (RepositoryException e) {
+				// do nothing, expected
 			}
 
 		}
+
 		try (SailRepositoryConnection connection = shaclRepository.getConnection()) {
 			assertEquals(0, size(connection));
-
 		}
 
 	}


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1425 .

Briefly describe the changes proposed in this PR:

* `removeStatements` needs only flush if there are pending added statements
* introduced default impl `pendingRemoved` for `AbstractConnection`
* this is WIP as some tests for SHACL fail.

The above fix brings removal operation performance from 20 seconds down to milliseconds. 
