### PR TITLE
eclipse/rdf4j#1453 native store context cache

### DIFF
--- a/nativerdf/pom.xml
+++ b/nativerdf/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -71,14 +73,26 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
-        <build>
-                <plugins>
-                        <plugin>
-                                <groupId>com.github.siom79.japicmp</groupId>
-                                <artifactId>japicmp-maven-plugin</artifactId>
-                        </plugin>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
@@ -109,7 +109,7 @@ public class ContextStore implements Iterable<Resource> {
 	 * @param context the context identifier.
 	 * @param amount  the number by which to decrease the size
 	 */
-	public void decrementBy(Resource context, int amount) {
+	public void decrementBy(Resource context, long amount) {
 		contextInfoMap.computeIfPresent(context, (c, size) -> size <= amount ? null : size - amount);
 		contentsChanged = true;
 	}

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
@@ -73,12 +73,12 @@ public class ContextStore implements Iterable<Resource> {
 
 	private final ValueFactory valueFactory;
 
-	public ContextStore(NativeSailStore store, File dataDir, ValueFactory valueFactory) throws IOException {
+	public ContextStore(NativeSailStore store, File dataDir) throws IOException {
+		Objects.requireNonNull(store);
 		Objects.requireNonNull(dataDir);
-		Objects.requireNonNull(valueFactory);
 
 		this.file = new File(dataDir, FILE_NAME);
-		this.valueFactory = valueFactory;
+		this.valueFactory = store.getValueFactory();
 
 		contextInfoMap = new HashMap<>(16);
 

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
@@ -195,6 +195,8 @@ public class ContextStore implements Iterable<Resource> {
 						contextInfoMap.put(context, contextSize);
 					} catch (EOFException e) {
 						break;
+					} catch (IllegalArgumentException e) {
+						throw new IOException("unable to parse context identifier: ", e);
 					}
 				}
 

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
@@ -110,7 +110,7 @@ public class ContextStore implements Iterable<Resource> {
 	 * @param amount  the number by which to decrease the size
 	 */
 	public void decrementBy(Resource context, int amount) {
-		contextInfoMap.computeIfPresent(context, (c, size) -> size == 1L ? null : size - amount);
+		contextInfoMap.computeIfPresent(context, (c, size) -> size <= amount ? null : size - amount);
 		contentsChanged = true;
 	}
 

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.nativerdf;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.eclipse.rdf4j.common.io.IOUtil;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An in-memory index for context information that uses a file for persistence. Contexts are encoded in the file as
+ * records as follows:
+ * 
+ * <pre>
+ *   byte 1 - 8      : the number of statements in the content, as a long.
+ *   byte 9          : boolean flag indicating the type of context identifier (1 = IRI, 0 = blank node)
+ *   byte 10 - 11     : the length of the encoded context identifier
+ *   byte 12 - A     : the UTF-8 encoded the encoded context identifer
+ * </pre>
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class ContextStore implements Iterable<Resource> {
+
+	static final Logger logger = LoggerFactory.getLogger(ContextStore.class);
+
+	private static final String FILE_NAME = "contexts.dat";
+
+	/**
+	 * Magic number "Native Context File" to detect whether the file is actually a context file. The first three bytes
+	 * of the file should be equal to this magic number.
+	 */
+	private static final byte[] MAGIC_NUMBER = new byte[] { 'n', 'c', 'f' };
+
+	/**
+	 * File format version, stored as the fourth byte in context files.
+	 */
+	private static final byte FILE_FORMAT_VERSION = 1;
+
+	/**
+	 * The data file for this {@link ContextStore}.
+	 */
+	private final File file;
+
+	private final Map<Resource, Long> contextInfoMap;
+
+	/**
+	 * Flag indicating whether the contents of this {@link ContextStore} are different from what is stored on disk.
+	 */
+	private volatile boolean contentsChanged;
+
+	private final ValueFactory valueFactory;
+
+	public ContextStore(NativeSailStore store, File dataDir, ValueFactory valueFactory) throws IOException {
+		Objects.requireNonNull(dataDir);
+		Objects.requireNonNull(valueFactory);
+
+		this.file = new File(dataDir, FILE_NAME);
+		this.valueFactory = valueFactory;
+
+		contextInfoMap = new HashMap<>(16);
+
+		if (file.exists()) {
+			readContextsFromFile();
+		} else {
+			logger.info("no context index file found, reconstructing from store (this may take a while)");
+			store.initializeContextCache();
+			// Make sure the file exists
+			writeContextsToFile();
+			logger.info("context index reconstruction complete");
+		}
+	}
+
+	/**
+	 * Increase the size of the context. If the context was not yet known, it is created with a size of 1.
+	 * 
+	 * @param context the context identifier.
+	 */
+	public void increment(Resource context) {
+		contextInfoMap.merge(context, 1L, (size, one) -> size + one);
+		contentsChanged = true;
+	}
+
+	/**
+	 * Decrease the size of the context by the given amount. If the size reaches zero, the context is removed.
+	 * 
+	 * @param context the context identifier.
+	 * @param amount  the number by which to decrease the size
+	 */
+	public void decrementBy(Resource context, int amount) {
+		contextInfoMap.computeIfPresent(context, (c, size) -> size == 1L ? null : size - amount);
+		contentsChanged = true;
+	}
+
+	@Override
+	public Iterator<Resource> iterator() {
+		return contextInfoMap.keySet().iterator();
+	}
+
+	public void clear() {
+		if (!contextInfoMap.isEmpty()) {
+			contextInfoMap.clear();
+			contentsChanged = true;
+		}
+	}
+
+	public void close() {
+	}
+
+	public void sync() throws IOException {
+		if (contentsChanged) {
+			// Flush the changes to disk
+			writeContextsToFile();
+			contentsChanged = false;
+		}
+	}
+
+	private void writeContextsToFile() throws IOException {
+		synchronized (file) {
+			try (DataOutputStream out = new DataOutputStream(new FileOutputStream(file))) {
+				out.write(MAGIC_NUMBER);
+				out.writeByte(FILE_FORMAT_VERSION);
+				for (Entry<Resource, Long> entry : contextInfoMap.entrySet()) {
+					out.writeLong(entry.getValue());
+					out.writeBoolean(entry.getKey() instanceof IRI);
+					out.writeUTF(entry.getKey().stringValue());
+				}
+			}
+		}
+	}
+
+	private void readContextsFromFile() throws IOException {
+		synchronized (file) {
+			try (DataInputStream in = new DataInputStream(new FileInputStream(file))) {
+				byte[] magicNumber = IOUtil.readBytes(in, MAGIC_NUMBER.length);
+				if (!Arrays.equals(magicNumber, MAGIC_NUMBER)) {
+					throw new IOException("File doesn't contain compatible context data");
+				}
+
+				byte version = in.readByte();
+				if (version > FILE_FORMAT_VERSION) {
+					throw new IOException("Unable to read context file; it uses a newer file format");
+				} else if (version != FILE_FORMAT_VERSION) {
+					throw new IOException("Unable to read context file; invalid file format version: " + version);
+				}
+
+				while (true) {
+					try {
+						long contextSize = in.readLong();
+						boolean isIRI = in.readBoolean();
+						String contextId = in.readUTF();
+
+						Resource context = isIRI ? valueFactory.createIRI(contextId)
+								: valueFactory.createBNode(contextId);
+						contextInfoMap.put(context, contextSize);
+					} catch (EOFException e) {
+						break;
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ContextStore.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * @author Jeen Broekstra
  *
  */
-public class ContextStore implements Iterable<Resource> {
+class ContextStore implements Iterable<Resource> {
 
 	static final Logger logger = LoggerFactory.getLogger(ContextStore.class);
 
@@ -84,7 +84,7 @@ public class ContextStore implements Iterable<Resource> {
 
 	private final ValueFactory valueFactory;
 
-	public ContextStore(NativeSailStore store, File dataDir) throws IOException {
+	ContextStore(NativeSailStore store, File dataDir) throws IOException {
 		Objects.requireNonNull(store);
 		Objects.requireNonNull(dataDir);
 
@@ -109,7 +109,7 @@ public class ContextStore implements Iterable<Resource> {
 	 * 
 	 * @param context the context identifier.
 	 */
-	public void increment(Resource context) {
+	void increment(Resource context) {
 		contextInfoMap.merge(context, 1L, (size, one) -> size + one);
 		contentsChanged = true;
 	}
@@ -120,7 +120,7 @@ public class ContextStore implements Iterable<Resource> {
 	 * @param context the context identifier.
 	 * @param amount  the number by which to decrease the size
 	 */
-	public void decrementBy(Resource context, long amount) {
+	void decrementBy(Resource context, long amount) {
 		contextInfoMap.computeIfPresent(context, (c, size) -> size <= amount ? null : size - amount);
 		contentsChanged = true;
 	}
@@ -130,17 +130,17 @@ public class ContextStore implements Iterable<Resource> {
 		return contextInfoMap.keySet().iterator();
 	}
 
-	public void clear() {
+	void clear() {
 		if (!contextInfoMap.isEmpty()) {
 			contextInfoMap.clear();
 			contentsChanged = true;
 		}
 	}
 
-	public void close() {
+	void close() {
 	}
 
-	public void sync() throws IOException {
+	void sync() throws IOException {
 		if (contentsChanged) {
 			// Flush the changes to disk
 			writeContextsToFile();

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
@@ -356,10 +356,14 @@ class NativeSailStore implements SailStore {
 					try {
 						namespaceStore.sync();
 					} finally {
-						if (storeTxnStarted.get()) {
-							tripleStore.commit();
-							// do not set flag to false until _after_ commit is succesfully completed.
-							storeTxnStarted.set(false);
+						try {
+							contextStore.sync();
+						} finally {
+							if (storeTxnStarted.get()) {
+								tripleStore.commit();
+								// do not set flag to false until _after_ commit is succesfully completed.
+								storeTxnStarted.set(false);
+							}
 						}
 					}
 				}

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
@@ -20,12 +20,8 @@ import org.eclipse.rdf4j.IsolationLevel;
 import org.eclipse.rdf4j.OpenRDFUtil;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
-import org.eclipse.rdf4j.common.iteration.ConvertingIteration;
-import org.eclipse.rdf4j.common.iteration.DistinctIteration;
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
-import org.eclipse.rdf4j.common.iteration.ExceptionConvertingIteration;
 import org.eclipse.rdf4j.common.iteration.FilterIteration;
-import org.eclipse.rdf4j.common.iteration.ReducedIteration;
 import org.eclipse.rdf4j.common.iteration.UnionIteration;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Namespace;
@@ -60,6 +56,8 @@ class NativeSailStore implements SailStore {
 
 	final NamespaceStore namespaceStore;
 
+	final ContextStore contextStore;
+
 	/**
 	 * A lock to control concurrent access by {@link NativeSailSink} to the TripleStore, ValueStore, and NamespaceStore.
 	 * Each sink method that directly accesses one of these store obtains the lock and releases it immediately when
@@ -91,6 +89,7 @@ class NativeSailStore implements SailStore {
 			valueStore = new ValueStore(dataDir, forceSync, valueCacheSize, valueIDCacheSize, namespaceCacheSize,
 					namespaceIDCacheSize);
 			tripleStore = new TripleStore(dataDir, tripleIndexes, forceSync);
+			contextStore = new ContextStore(this, dataDir, getValueFactory());
 			initialized = true;
 		} finally {
 			if (!initialized) {
@@ -113,14 +112,21 @@ class NativeSailStore implements SailStore {
 				}
 			} finally {
 				try {
-					if (valueStore != null) {
-						valueStore.close();
+					if (contextStore != null) {
+						contextStore.close();
 					}
 				} finally {
-					if (tripleStore != null) {
-						tripleStore.close();
+					try {
+						if (valueStore != null) {
+							valueStore.close();
+						}
+					} finally {
+						if (tripleStore != null) {
+							tripleStore.close();
+						}
 					}
 				}
+
 			}
 		} catch (IOException e) {
 			logger.warn("Failed to close store", e);
@@ -164,6 +170,33 @@ class NativeSailStore implements SailStore {
 		}
 
 		return contextIDs;
+	}
+
+	void initializeContextCache() throws IOException {
+		logger.debug("initializing context cache");
+		RecordIterator btreeIter = tripleStore.getAllTriplesSortedByContext(false);
+		CloseableIteration<? extends Statement, SailException> stIter1;
+		if (btreeIter == null) {
+			// Iterator over all statements
+			stIter1 = createStatementIterator(null, null, null, true);
+		} else {
+			stIter1 = new NativeStatementIterator(btreeIter, valueStore);
+		}
+
+		// Filter statements without context resource
+		try (FilterIteration<Statement, SailException> stIter2 = new FilterIteration<Statement, SailException>(
+				stIter1) {
+
+			@Override
+			protected boolean accept(Statement st) {
+				return st.getContext() != null;
+			}
+		}) {
+			while (stIter2.hasNext()) {
+				Statement st = stIter2.next();
+				contextStore.increment(st.getContext());
+			}
+		}
 	}
 
 	/**
@@ -433,6 +466,9 @@ class NativeSailStore implements SailStore {
 					}
 
 					boolean wasNew = tripleStore.storeTriple(subjID, predID, objID, contextID, explicit);
+					if (wasNew && context != null) {
+						contextStore.increment(context);
+					}
 					result |= wasNew;
 				}
 			} catch (IOException e) {
@@ -476,30 +512,17 @@ class NativeSailStore implements SailStore {
 					}
 				}
 
-				List<Integer> contextIDList = new ArrayList<>(contexts.length);
 				if (contexts.length == 0) {
-					contextIDList.add(NativeValue.UNKNOWN_ID);
-				} else {
-					for (Resource context : contexts) {
-						if (context == null) {
-							contextIDList.add(0);
-						} else {
-							int contextID = valueStore.getID(context);
-							if (contextID != NativeValue.UNKNOWN_ID) {
-								contextIDList.add(contextID);
-							}
-						}
-					}
+					return tripleStore.removeTriples(subjID, predID, objID, NativeValue.UNKNOWN_ID, explicit);
 				}
 
 				int removeCount = 0;
-
-				for (int i = 0; i < contextIDList.size(); i++) {
-					int contextID = contextIDList.get(i);
-
-					removeCount += tripleStore.removeTriples(subjID, predID, objID, contextID, explicit);
+				for (Resource context : contexts) {
+					int contextId = context == null ? 0 : valueStore.getID(context);
+					int count = tripleStore.removeTriples(subjID, predID, objID, contextId, explicit);
+					contextStore.decrementBy(context, count);
+					removeCount += count;
 				}
-
 				return removeCount;
 			} catch (IOException e) {
 				throw new SailException(e);
@@ -540,108 +563,7 @@ class NativeSailStore implements SailStore {
 
 		@Override
 		public CloseableIteration<? extends Resource, SailException> getContextIDs() throws SailException {
-			RecordIterator btreeIter = null;
-			CloseableIteration<? extends Statement, SailException> stIter1 = null;
-			CloseableIteration<? extends Statement, SailException> stIter2 = null;
-			CloseableIteration<Resource, SailException> ctxIter1 = null;
-			CloseableIteration<Resource, SailException> ctxIter2 = null;
-			ExceptionConvertingIteration<Resource, SailException> result = null;
-			boolean allGood = false;
-			// Which resources are used as context identifiers is not stored
-			// separately. Iterate over all statements and extract their context.
-			try {
-				btreeIter = tripleStore.getAllTriplesSortedByContext(false);
-				if (btreeIter == null) {
-					// Iterator over all statements
-					stIter1 = createStatementIterator(null, null, null, explicit);
-				} else {
-					stIter1 = new NativeStatementIterator(btreeIter, valueStore);
-				}
-				// Filter statements without context resource
-				stIter2 = new FilterIteration<Statement, SailException>(stIter1) {
-
-					@Override
-					protected boolean accept(Statement st) {
-						return st.getContext() != null;
-					}
-				};
-				// Return the contexts of the statements
-				ctxIter1 = new ConvertingIteration<Statement, Resource, SailException>(stIter2) {
-
-					@Override
-					protected Resource convert(Statement st) {
-						return st.getContext();
-					}
-				};
-				if (btreeIter == null) {
-					// Filtering any duplicates
-					ctxIter2 = new DistinctIteration<>(ctxIter1);
-				} else {
-					// Filtering sorted duplicates
-					ctxIter2 = new ReducedIteration<>(ctxIter1);
-				}
-
-				result = new ExceptionConvertingIteration<Resource, SailException>(ctxIter2) {
-
-					@Override
-					protected SailException convert(Exception e) {
-						if (e instanceof IOException) {
-							return new SailException(e);
-						} else if (e instanceof RuntimeException) {
-							throw (RuntimeException) e;
-						} else if (e == null) {
-							throw new IllegalArgumentException("e must not be null");
-						} else {
-							throw new IllegalArgumentException("Unexpected exception type: " + e.getClass());
-						}
-					}
-				};
-				allGood = true;
-				return result;
-			} catch (IOException e) {
-				throw new SailException(e);
-			} finally {
-				if (!allGood) {
-					try {
-						if (result != null) {
-							result.close();
-						}
-					} finally {
-						try {
-							if (ctxIter2 != null) {
-								ctxIter2.close();
-							}
-						} finally {
-							try {
-								if (ctxIter1 != null) {
-									ctxIter1.close();
-								}
-							} finally {
-								try {
-									if (stIter2 != null) {
-										stIter2.close();
-									}
-								} finally {
-									try {
-										if (stIter1 != null) {
-											stIter1.close();
-										}
-									} finally {
-										if (btreeIter != null) {
-											try {
-												btreeIter.close();
-											} catch (IOException e) {
-												throw new SailException(e);
-											}
-										}
-									}
-								}
-							}
-						}
-
-					}
-				}
-			}
+			return new CloseableIteratorIteration<Resource, SailException>(contextStore.iterator());
 		}
 
 		@Override
@@ -654,4 +576,5 @@ class NativeSailStore implements SailStore {
 			}
 		}
 	}
+
 }

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
@@ -524,7 +524,9 @@ class NativeSailStore implements SailStore {
 				for (Resource context : contexts) {
 					int contextId = context == null ? 0 : valueStore.getID(context);
 					int count = tripleStore.removeTriples(subjID, predID, objID, contextId, explicit);
-					contextStore.decrementBy(context, count);
+					if (context != null) {
+						contextStore.decrementBy(context, count);
+					}
 					removeCount += count;
 				}
 				return removeCount;

--- a/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
+++ b/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/NativeSailStore.java
@@ -89,7 +89,7 @@ class NativeSailStore implements SailStore {
 			valueStore = new ValueStore(dataDir, forceSync, valueCacheSize, valueIDCacheSize, namespaceCacheSize,
 					namespaceIDCacheSize);
 			tripleStore = new TripleStore(dataDir, tripleIndexes, forceSync);
-			contextStore = new ContextStore(this, dataDir, getValueFactory());
+			contextStore = new ContextStore(this, dataDir);
 			initialized = true;
 		} finally {
 			if (!initialized) {

--- a/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
+++ b/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
@@ -84,6 +84,15 @@ public class ContextStoreTest {
 	}
 
 	@Test
+	public void testDecrementExistingBySeveral() throws Exception {
+		subject.increment(g1);
+		subject.increment(g1);
+
+		subject.decrementBy(g1, 2);
+		assertThat(countContexts(subject)).isEqualTo(0);
+	}
+
+	@Test
 	public void testDecrementExistingBNode() throws Exception {
 		subject.increment(g2);
 		subject.increment(g2);

--- a/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
+++ b/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
@@ -115,13 +115,13 @@ public class ContextStoreTest {
 		File datafile = new File(dir, "contexts.dat");
 		assertThat(datafile.exists());
 		long size = datafile.length();
-		assertThat(size).isEqualTo(4L); // empty contexts file is 4 bytes
+		assertThat(size).isEqualTo(8L); // empty contexts file is 8 bytes
 		subject.increment(g1);
 		subject.sync();
-		assertThat(datafile.length()).isGreaterThan(4L);
+		assertThat(datafile.length()).isGreaterThan(8L);
 		subject.decrementBy(g1, 1);
 		subject.sync();
-		assertThat(datafile.length()).isEqualTo(4L);
+		assertThat(datafile.length()).isEqualTo(8L);
 	}
 
 	private int countContexts(ContextStore subject) {

--- a/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
+++ b/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.sail.nativerdf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 
@@ -46,8 +47,9 @@ public class ContextStoreTest {
 		dir = Files.createTempDir();
 		NativeSailStore sailStore = mock(NativeSailStore.class);
 		doNothing().when(sailStore).initializeContextCache();
+		when(sailStore.getValueFactory()).thenReturn(SimpleValueFactory.getInstance());
 
-		subject = new ContextStore(sailStore, dir, vf);
+		subject = new ContextStore(sailStore, dir);
 	}
 
 	@Test

--- a/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
+++ b/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ContextStoreTest.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.nativerdf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.io.Files;
+
+/**
+ * Unit tests for {@link ContextStore}
+ * 
+ * @author Jeen Broekstra
+ *
+ */
+public class ContextStoreTest {
+
+	private ContextStore subject;
+
+	private static ValueFactory vf = SimpleValueFactory.getInstance();
+
+	private Resource g1 = vf.createIRI("http://example.org/g1");
+	private Resource g2 = vf.createBNode();
+
+	private File dir;
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+		dir = Files.createTempDir();
+		NativeSailStore sailStore = mock(NativeSailStore.class);
+		doNothing().when(sailStore).initializeContextCache();
+
+		subject = new ContextStore(sailStore, dir, vf);
+	}
+
+	@Test
+	public void testIncrementNew() throws Exception {
+		subject.increment(g1);
+		assertThat(countContexts(subject)).isEqualTo(1);
+	}
+
+	@Test
+	public void testIncrementNewBNode() throws Exception {
+		subject.increment(g2);
+		assertThat(countContexts(subject)).isEqualTo(1);
+	}
+
+	@Test
+	public void testIncrementExisting() throws Exception {
+		subject.increment(g1);
+		subject.increment(g1);
+		assertThat(countContexts(subject)).isEqualTo(1);
+	}
+
+	@Test
+	public void testDecrementExisting() throws Exception {
+		subject.increment(g1);
+		subject.increment(g1);
+
+		subject.decrementBy(g1, 1);
+		assertThat(countContexts(subject)).isEqualTo(1);
+
+		subject.decrementBy(g1, 1);
+		assertThat(countContexts(subject)).isEqualTo(0);
+	}
+
+	@Test
+	public void testDecrementExistingBNode() throws Exception {
+		subject.increment(g2);
+		subject.increment(g2);
+
+		subject.decrementBy(g2, 1);
+		assertThat(countContexts(subject)).isEqualTo(1);
+
+		subject.decrementBy(g2, 1);
+		assertThat(countContexts(subject)).isEqualTo(0);
+	}
+
+	@Test
+	public void testDecrementNonExisting() throws Exception {
+		subject.decrementBy(g1, 1);
+		assertThat(countContexts(subject)).isEqualTo(0);
+	}
+
+	@Test
+	public void testSync() throws Exception {
+		File datafile = new File(dir, "contexts.dat");
+		assertThat(datafile.exists());
+		long size = datafile.length();
+		assertThat(size).isEqualTo(4L); // empty contexts file is 4 bytes
+		subject.increment(g1);
+		subject.sync();
+		assertThat(datafile.length()).isGreaterThan(4L);
+		subject.decrementBy(g1, 1);
+		subject.sync();
+		assertThat(datafile.length()).isEqualTo(4L);
+	}
+
+	private int countContexts(ContextStore subject) {
+		int count = 0;
+		for (Resource c : subject) {
+			count++;
+		}
+		return count;
+	}
+
+}

--- a/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTxnTest.java
+++ b/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTxnTest.java
@@ -20,7 +20,6 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
-import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -76,7 +75,7 @@ public class NativeStoreTxnTest {
 		for (File file : repoDir.listFiles()) {
 			System.out.println("# " + file.getName());
 		}
-		Assert.assertEquals(14, repoDir.listFiles().length);
+		Assert.assertEquals(15, repoDir.listFiles().length);
 
 		// make sure there is no txncacheXXX.dat file
 		Assert.assertFalse(Files.list(repoDir.getAbsoluteFile().toPath())


### PR DESCRIPTION
includes persistent storage and seemless upgrade of existing stores that
miss this file.


This PR addresses GitHub issue: eclipse/rdf4j#1453 .

Briefly describe the changes proposed in this PR:

* added ContextStore, an in-memory index of context identifiers with on-disk persistence
* added seemless upgrade on initialization of existing native stores
* added a few unit tests

I did a few quick manual performance tests (inspired by the reported problems in eclipse/rdf4j#1452). Environment: native store with approx 10M statements, running on local linux laptop. 

Before: getContextIDs took approx. 20-30 seconds.
After: one-time initialization of the cache file took 10-20 seconds. getContextIDs took 1-2 seconds. 