### PR TITLE
Make LuceneSailConnection to replace query patterns with results inplace

### DIFF
--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractSearchQueryEvaluator.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/AbstractSearchQueryEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Eclipse RDF4J contributors, Aduna, and others.
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -8,19 +8,19 @@
 package org.eclipse.rdf4j.sail.lucene;
 
 import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.algebra.EmptySet;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 
-public interface SearchQueryEvaluator {
+public abstract class AbstractSearchQueryEvaluator implements SearchQueryEvaluator {
 
-	QueryModelNode getParentQueryModelNode();
+	@Override
+	public void replaceQueryPatternsWithResults(final BindingSetAssignment bsa) {
+		final QueryModelNode placeholder = removeQueryPatterns();
+		if (bsa != null && bsa.getBindingSets() != null && bsa.getBindingSets().iterator().hasNext()) {
+			placeholder.replaceWith(bsa);
+		} else {
+			placeholder.replaceWith(new EmptySet());
+		}
+	}
 
-	/**
-	 * @param bsa if null or empty then there're no results for the query
-	 */
-	void replaceQueryPatternsWithResults(final BindingSetAssignment bsa);
-
-	/**
-	 * Removes the query patterns and returns a placeholder where the query results could be placed.
-	 */
-	QueryModelNode removeQueryPatterns();
 }

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpec.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpec.java
@@ -12,7 +12,6 @@ import java.util.List;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.query.algebra.EmptySet;
 import org.eclipse.rdf4j.query.algebra.Extension;
 import org.eclipse.rdf4j.query.algebra.ExtensionElem;
 import org.eclipse.rdf4j.query.algebra.Filter;
@@ -24,7 +23,7 @@ import org.eclipse.rdf4j.query.algebra.ValueConstant;
 import org.eclipse.rdf4j.query.algebra.ValueExpr;
 import org.eclipse.rdf4j.query.algebra.Var;
 
-public class DistanceQuerySpec implements SearchQueryEvaluator {
+public class DistanceQuerySpec extends AbstractSearchQueryEvaluator {
 
 	private FunctionCall distanceFunction;
 
@@ -181,15 +180,12 @@ public class DistanceQuerySpec implements SearchQueryEvaluator {
 	}
 
 	@Override
-	public void updateQueryModelNodes(boolean hasResult) {
-		QueryModelNode replacementNode = hasResult ? new SingletonSet() : new EmptySet();
-		geoStatement.replaceWith(replacementNode);
+	public QueryModelNode removeQueryPatterns() {
+		final QueryModelNode placeholder = new SingletonSet();
 
-		if (hasResult) {
-			filter.replaceWith(filter.getArg());
-		} else {
-			filter.replaceWith(new EmptySet());
-		}
+		filter.replaceWith(filter.getArg());
+
+		geoStatement.replaceWith(placeholder);
 
 		QueryModelNode functionParent = distanceFunction.getParentNode();
 		if (functionParent instanceof ExtensionElem) {
@@ -201,6 +197,8 @@ public class DistanceQuerySpec implements SearchQueryEvaluator {
 				extension.replaceWith(extension.getArg());
 			}
 		}
+
+		return placeholder;
 	}
 
 	public boolean isEvaluable() {

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecBuilder.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecBuilder.java
@@ -128,7 +128,8 @@ public class DistanceQuerySpecBuilder implements SearchQueryInterpreter {
 							sp.replaceWith(join);
 							join.setLeftArg(sp);
 							join.setRightArg(funcCall);
-							spec.updateQueryModelNodes(true);
+
+							spec.removeQueryPatterns();
 						}
 					}
 				}

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/GeoRelationQuerySpec.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/GeoRelationQuerySpec.java
@@ -20,7 +20,7 @@ import org.eclipse.rdf4j.query.algebra.SingletonSet;
 import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.Var;
 
-public class GeoRelationQuerySpec implements SearchQueryEvaluator {
+public class GeoRelationQuerySpec extends AbstractSearchQueryEvaluator {
 
 	private String relation;
 
@@ -105,15 +105,12 @@ public class GeoRelationQuerySpec implements SearchQueryEvaluator {
 	}
 
 	@Override
-	public void updateQueryModelNodes(boolean hasResult) {
-		QueryModelNode replacementNode = hasResult ? new SingletonSet() : new EmptySet();
-		geoStatement.replaceWith(replacementNode);
+	public QueryModelNode removeQueryPatterns() {
+		final QueryModelNode placeholder = new SingletonSet();
 
-		if (hasResult) {
-			filter.replaceWith(filter.getArg());
-		} else {
-			filter.replaceWith(new EmptySet());
-		}
+		filter.replaceWith(filter.getArg());
+
+		geoStatement.replaceWith(placeholder);
 
 		if (functionParent instanceof ExtensionElem) {
 			Extension extension = (Extension) functionParent.getParentNode();
@@ -124,5 +121,7 @@ public class GeoRelationQuerySpec implements SearchQueryEvaluator {
 				extension.replaceWith(extension.getArg());
 			}
 		}
+
+		return placeholder;
 	}
 }

--- a/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilder.java
+++ b/lucene-api/src/main/java/org/eclipse/rdf4j/sail/lucene/QuerySpecBuilder.java
@@ -52,7 +52,7 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 
 	/**
 	 * Initialize a new QuerySpecBuilder
-	 * 
+	 *
 	 * @param incompleteQueryFails see {@link LuceneSail#isIncompleteQueryFails()}
 	 */
 	public QuerySpecBuilder(boolean incompleteQueryFails) {
@@ -61,7 +61,7 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 
 	/**
 	 * Returns a set of QuerySpecs embodying all necessary information to perform the Lucene query embedded in a
-	 * TupleExpr. To be removed, prefer {@link process(TupleExpr tupleExpr, BindingSet bindings, Collection
+	 * TupleExpr. To be removed, prefer {@link #process(TupleExpr tupleExpr, BindingSet bindings, Collection
 	 * <SearchQueryEvaluator> result)}.
 	 */
 	@SuppressWarnings("unchecked")
@@ -208,7 +208,8 @@ public class QuerySpecBuilder implements SearchQueryInterpreter {
 				matchesPattern.replaceWith(join);
 				join.setLeftArg(matchesPattern);
 				join.setRightArg(funcCall);
-				querySpec.updateQueryModelNodes(true);
+
+				querySpec.removeQueryPatterns();
 			}
 		}
 

--- a/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecTest.java
+++ b/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/DistanceQuerySpecTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.eclipse.rdf4j.model.vocabulary.GEOF;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.query.impl.MapBindingSet;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DistanceQuerySpecTest extends SearchQueryEvaluatorTest {
+
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+
+	/**
+	 * Reused from {@link org.eclipse.rdf4j.sail.lucene.AbstractLuceneSailGeoSPARQLTest}
+	 */
+	private static final String QUERY = "PREFIX geo:  <" + GEO.NAMESPACE + ">\n" +
+			"PREFIX geof: <" + GEOF.NAMESPACE + ">" +
+			"PREFIX uom: <http://www.opengis.net/def/uom/OGC/1.0/>\n" +
+			"SELECT ?toUri ?to { " +
+			"   ?toUri geo:asWKT ?to . " +
+			"   FILTER(geof:distance(\"POINT (2.2871 48.8630)\"^^geo:wktLiteral, ?to, uom:metre) < \"1500.0\")" +
+			"}";
+
+	@Test
+	public void testReplaceQueryPatternsWithNonEmptyResults() {
+		final String expectedQueryPlan = "Projection\n" +
+				"   ProjectionElemList\n" +
+				"      ProjectionElem \"toUri\"\n" +
+				"      ProjectionElem \"to\"\n" +
+				"   BindingSetAssignment ([[toUri=urn:subject1;to=\"POINT (2.2945 48.8582)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>]])\n";
+		final ParsedQuery query = parseQuery(QUERY);
+
+		final List<SearchQueryEvaluator> queries = new ArrayList<>();
+
+		new DistanceQuerySpecBuilder(new SearchIndexImpl())
+				.process(query.getTupleExpr(), EmptyBindingSet.getInstance(), queries);
+		assertEquals(1, queries.size());
+
+		final DistanceQuerySpec querySpec = (DistanceQuerySpec) queries.get(0);
+
+		final MapBindingSet bindingSet = new MapBindingSet();
+		bindingSet.addBinding("toUri", VF.createIRI("urn:subject1"));
+		bindingSet.addBinding("to", VF.createLiteral("POINT (2.2945 48.8582)", GEO.WKT_LITERAL));
+
+		BindingSetAssignment bsa = new BindingSetAssignment();
+		bsa.setBindingSets(Collections.singletonList(bindingSet));
+
+		querySpec.replaceQueryPatternsWithResults(bsa);
+
+		assertEquals(
+				expectedQueryPlan,
+				querySpec.getParentQueryModelNode().getParentNode().toString());
+	}
+
+	@Test
+	public void testReplaceQueryPatternsWithEmptyResults() {
+		final String expectedQueryPlan = "Projection\n" +
+				"   ProjectionElemList\n" +
+				"      ProjectionElem \"toUri\"\n" +
+				"      ProjectionElem \"to\"\n" +
+				"   EmptySet\n";
+		final ParsedQuery query = parseQuery(QUERY);
+
+		final List<SearchQueryEvaluator> queries = new ArrayList<>();
+
+		new DistanceQuerySpecBuilder(new SearchIndexImpl())
+				.process(query.getTupleExpr(), EmptyBindingSet.getInstance(), queries);
+		assertEquals(1, queries.size());
+
+		final DistanceQuerySpec querySpec = (DistanceQuerySpec) queries.get(0);
+
+		querySpec.replaceQueryPatternsWithResults(new BindingSetAssignment());
+
+		assertEquals(
+				expectedQueryPlan,
+				querySpec.getParentQueryModelNode().getParentNode().toString());
+	}
+
+}

--- a/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/GeoRelationQuerySpecTest.java
+++ b/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/GeoRelationQuerySpecTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.eclipse.rdf4j.model.vocabulary.GEOF;
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.query.impl.MapBindingSet;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class GeoRelationQuerySpecTest extends SearchQueryEvaluatorTest {
+
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+	private static final String QUERY = "PREFIX geo:  <" + GEO.NAMESPACE + ">\n" +
+			"PREFIX geof: <" + GEOF.NAMESPACE + ">" +
+			"PREFIX uom: <http://www.opengis.net/def/uom/OGC/1.0/>\n" +
+			"SELECT ?matchUri ?match { " +
+			"   ?matchUri geo:asWKT ?match . " +
+			"   FILTER(geof:sfIntersects(\"POLYGON ((2.315 48.855, 2.360 48.835, 2.370 48.850, 2.315 48.855))\"^^geo:wktLiteral, ?match)) "
+			+
+			"}";
+
+	@Test
+	public void testReplaceQueryPatternsWithNonEmptyResults() {
+		final String expectedQueryPlan = "Projection\n" +
+				"   ProjectionElemList\n" +
+				"      ProjectionElem \"matchUri\"\n" +
+				"      ProjectionElem \"match\"\n" +
+				"   BindingSetAssignment ([[toUri=urn:subject4;to=\"POLYGON ((2.3294 48.8726, 2.2719 48.8643, 2.3370 48.8398, 2.3294 48.8726))\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>]])\n";
+		final ParsedQuery query = parseQuery(QUERY);
+
+		final List<SearchQueryEvaluator> queries = new ArrayList<>();
+
+		new GeoRelationQuerySpecBuilder(new SearchIndexImpl())
+				.process(query.getTupleExpr(), EmptyBindingSet.getInstance(), queries);
+		assertEquals(1, queries.size());
+
+		final GeoRelationQuerySpec querySpec = (GeoRelationQuerySpec) queries.get(0);
+
+		final MapBindingSet bindingSet = new MapBindingSet();
+		bindingSet.addBinding("toUri", VF.createIRI("urn:subject4"));
+		bindingSet.addBinding("to", VF.createLiteral(
+				"POLYGON ((2.3294 48.8726, 2.2719 48.8643, 2.3370 48.8398, 2.3294 48.8726))", GEO.WKT_LITERAL));
+
+		BindingSetAssignment bsa = new BindingSetAssignment();
+		bsa.setBindingSets(Collections.singletonList(bindingSet));
+
+		querySpec.replaceQueryPatternsWithResults(bsa);
+
+		assertEquals(
+				expectedQueryPlan,
+				querySpec.getParentQueryModelNode().getParentNode().toString());
+	}
+
+	@Test
+	public void testReplaceQueryPatternsWithEmptyResults() {
+		final String expectedQueryPlan = "Projection\n" +
+				"   ProjectionElemList\n" +
+				"      ProjectionElem \"matchUri\"\n" +
+				"      ProjectionElem \"match\"\n" +
+				"   EmptySet\n";
+		final ParsedQuery query = parseQuery(QUERY);
+
+		final List<SearchQueryEvaluator> queries = new ArrayList<>();
+
+		new GeoRelationQuerySpecBuilder(new SearchIndexImpl())
+				.process(query.getTupleExpr(), EmptyBindingSet.getInstance(), queries);
+		assertEquals(1, queries.size());
+
+		final GeoRelationQuerySpec querySpec = (GeoRelationQuerySpec) queries.get(0);
+
+		BindingSetAssignment bsa = new BindingSetAssignment();
+
+		querySpec.replaceQueryPatternsWithResults(bsa);
+
+		assertEquals(
+				expectedQueryPlan,
+				querySpec.getParentQueryModelNode().getParentNode().toString());
+	}
+
+}

--- a/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/QuerySpecTest.java
+++ b/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/QuerySpecTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import org.eclipse.rdf4j.query.algebra.BindingSetAssignment;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.Assert.assertEquals;
+
+public class QuerySpecTest extends SearchQueryEvaluatorTest {
+	private static final String QUERY = "PREFIX search: <http://www.openrdf.org/contrib/lucenesail#>\n" +
+			"SELECT * {" +
+			"   ?searchR search:matches [" +
+			"       search:query \"test\" ;" +
+			"       search:score ?score" +
+			"   ] ." +
+			"   ?searchR rdfs:label ?label ." +
+			"}";
+
+	@Test
+	public void testReplaceQueryPatternsWithNonEmptyResults() {
+		final String expectedQueryPlan = "Join\n" +
+				"   Join\n" +
+				"      SingletonSet\n" +
+				"      SingletonSet\n" +
+				"   BindingSetAssignment ([[searchR=urn:1]])\n";
+		final ParsedQuery query = parseQuery(QUERY);
+		final List<SearchQueryEvaluator> queries = new ArrayList<>();
+		new QuerySpecBuilder(true)
+				.process(query.getTupleExpr(), EmptyBindingSet.getInstance(), queries);
+		assertEquals(1, queries.size());
+		QuerySpec querySpec = (QuerySpec) queries.get(0);
+		BindingSetAssignment bsa = new BindingSetAssignment();
+		bsa.setBindingSets(createBindingSet("searchR", "urn:1"));
+		querySpec.replaceQueryPatternsWithResults(bsa);
+		assertEquals(
+				expectedQueryPlan,
+				querySpec.getParentQueryModelNode().getParentNode().toString());
+	}
+
+	@Test
+	public void testReplaceQueryPatternsWithEmptyResults() {
+		final String expectedQueryPlan = "Join\n" +
+				"   Join\n" +
+				"      SingletonSet\n" +
+				"      SingletonSet\n" +
+				"   EmptySet\n";
+		final ParsedQuery query = parseQuery(QUERY);
+		final List<SearchQueryEvaluator> queries = new ArrayList<>();
+		new QuerySpecBuilder(true)
+				.process(query.getTupleExpr(), EmptyBindingSet.getInstance(), queries);
+		assertEquals(1, queries.size());
+		QuerySpec querySpec = (QuerySpec) queries.get(0);
+		BindingSetAssignment bsa = new BindingSetAssignment();
+		querySpec.replaceQueryPatternsWithResults(bsa);
+		assertEquals(
+				expectedQueryPlan,
+				querySpec.getParentQueryModelNode().getParentNode().toString());
+	}
+}

--- a/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/SearchQueryEvaluatorTest.java
+++ b/lucene-api/src/test/java/org/eclipse/rdf4j/sail/lucene/SearchQueryEvaluatorTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lucene;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.GEO;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.impl.MapBindingSet;
+import org.eclipse.rdf4j.query.parser.ParsedQuery;
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
+import org.eclipse.rdf4j.sail.SailException;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+abstract class SearchQueryEvaluatorTest {
+	protected ParsedQuery parseQuery(String query) {
+		return new SPARQLParser().parseQuery(query, "urn:base:");
+	}
+
+	protected Collection<BindingSet> createBindingSet(String name, String iri) {
+		MapBindingSet bindingSet = new MapBindingSet();
+		bindingSet.addBinding(name, SimpleValueFactory.getInstance().createIRI(iri));
+		return Collections.singletonList(bindingSet);
+	}
+
+	protected class SearchIndexImpl implements SearchIndex {
+		protected Set<String> wktFields = Collections.singleton(SearchFields.getPropertyField(GEO.AS_WKT));
+
+		@Override
+		public void initialize(Properties parameters) throws Exception {
+		}
+
+		@Override
+		public Collection<BindingSet> evaluate(QuerySpec query) throws SailException {
+			return null;
+		}
+
+		@Override
+		public Collection<BindingSet> evaluate(SearchQueryEvaluator query) throws SailException {
+			return null;
+		}
+
+		@Override
+		public void beginReading() throws IOException {
+		}
+
+		@Override
+		public void endReading() throws IOException {
+		}
+
+		@Override
+		public void shutDown() throws IOException {
+		}
+
+		@Override
+		public boolean accept(Literal literal) {
+			return false;
+		}
+
+		@Override
+		public boolean isGeoField(String propertyName) {
+			return (wktFields != null) && wktFields.contains(propertyName);
+		}
+
+		@Override
+		public void begin() throws IOException {
+		}
+
+		@Override
+		public void commit() throws IOException {
+		}
+
+		@Override
+		public void rollback() throws IOException {
+		}
+
+		@Override
+		public void addStatement(Statement statement) throws IOException {
+		}
+
+		@Override
+		public void removeStatement(Statement statement) throws IOException {
+		}
+
+		@Override
+		public void addRemoveStatements(Collection<Statement> added, Collection<Statement> removed) throws IOException {
+		}
+
+		@Override
+		public void clearContexts(Resource... contexts) throws IOException {
+		}
+
+		@Override
+		public void addDocuments(Resource subject, List<Statement> statements) throws IOException {
+		}
+
+		@Override
+		public void clear() throws IOException {
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Maxim Kolchin <kolchinmax@gmail.com>

This PR addresses GitHub issue: eclipse/rdf4j#1229.

Briefly describe the changes proposed in this PR:
  - Remove from LuceneSailConnection the code responsible for the inclusion of the query results into the query in the form of BindingSetAssigment. Move this functionality to SearchQueryEvaluator subclasses.
  - SearchQueryEvaluator subclasses replace the query patterns with the results in place instead of "smart" replacement mechanism used in LuceneSailConnection before.
  - Add unit tests for the subclasses.
