### PR TITLE
Use File.separator instead of hard-coded slash

### DIFF
--- a/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexLocationTest.java
+++ b/lucene/src/test/java/org/eclipse/rdf4j/sail/lucene/LuceneIndexLocationTest.java
@@ -96,7 +96,7 @@ public class LuceneIndexLocationTest {
 		Path lucenePath = repository.getDataDir().toPath().resolve(luceneIndexPath);
 
 		log.info("Lucene index location: {}", lucenePath);
-		Assert.assertEquals(dataDir.getAbsolutePath() + "/" + luceneIndexPath, lucenePath.toAbsolutePath().toString());
+		Assert.assertEquals(dataDir.getAbsolutePath() + File.separator + luceneIndexPath, lucenePath.toAbsolutePath().toString());
 
 		Assert.assertTrue(lucenePath.toFile().exists());
 		Assert.assertTrue(lucenePath.toFile().isDirectory());


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1466 .

Briefly describe the changes proposed in this PR:

* Use File.separator instead of hard-coded '/'
