### PR TITLE
eclipse/rdf4j#1124 upgrade to jetty 9.4 / servlet api 3.1

### DIFF
--- a/compliance/sparql/pom.xml
+++ b/compliance/sparql/pom.xml
@@ -16,7 +16,7 @@
 	<description>Tests for the SPARQL query language implementation</description>
 
 	<properties>
-		<jetty.version>7.0.2.v20100331</jetty.version>
+		<jetty.version>9.4.19.v20190610</jetty.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -178,13 +178,6 @@
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
 			<version>${jetty.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mortbay.jetty</groupId>
-			<artifactId>jetty-jsp-2.1</artifactId>
-			<version>${jetty.version}</version>
-			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>

--- a/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLEmbeddedServer.java
+++ b/compliance/sparql/src/test/java/org/eclipse/rdf4j/query/parser/sparql/SPARQLEmbeddedServer.java
@@ -10,9 +10,7 @@ package org.eclipse.rdf4j.query.parser.sparql;
 import java.io.File;
 import java.util.List;
 
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.nio.BlockingChannelConnector;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.eclipse.rdf4j.http.protocol.Protocol;
 import org.eclipse.rdf4j.repository.Repository;
@@ -36,7 +34,7 @@ public class SPARQLEmbeddedServer {
 
 	private static final String HOST = "localhost";
 
-	private static final int PORT = 18080;
+	private static final int PORT = 18080; // this port is hardcoded in some (service) query fixtures
 
 	private static final String SERVER_CONTEXT = "/rdf4j-server";
 
@@ -51,12 +49,7 @@ public class SPARQLEmbeddedServer {
 		this.repositoryIds = repositoryIds;
 		System.clearProperty("DEBUG");
 
-		jetty = new Server();
-
-		Connector conn = new BlockingChannelConnector();
-		conn.setHost(HOST);
-		conn.setPort(PORT);
-		jetty.addConnector(conn);
+		jetty = new Server(PORT);
 
 		WebAppContext webapp = new WebAppContext();
 		webapp.setContextPath(SERVER_CONTEXT);

--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>
-				<version>3.0.1</version>
+				<version>3.1.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1124 .

Briefly describe the changes proposed in this PR:

* bump jetty to 9.4
* bump servlet api to 3.1
* necessary to be able to run rdf4j server with servlet 3.1. 
