### PR TITLE
marked ExternalSet as deprecated.

### DIFF
--- a/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExternalSet.java
+++ b/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/ExternalSet.java
@@ -19,7 +19,10 @@ import org.eclipse.rdf4j.query.algebra.TupleExpr;
 
 /**
  * @author James Leigh
+ * 
+ * @deprecated since 3.0.
  */
+@Deprecated
 public abstract class ExternalSet extends AbstractQueryModelNode implements TupleExpr {
 
 	private static final long serialVersionUID = 3903453394409442226L;


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#506 .

Briefly describe the changes proposed in this PR:

* marked as deprecated in preparation for removal as obsolete in the next major release (see eclipse/rdf4j#1496)
