### PR TITLE
Issues/1396 benchmark junit faster

### DIFF
--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/AbstractShaclTest.java
@@ -30,6 +30,7 @@ import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.sail.shacl.results.ValidationReport;
+import org.junit.AfterClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -194,6 +195,11 @@ abstract public class AbstractShaclTest {
 
 		return ret;
 
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		GlobalValidationExecutionLogging.loggingEnabled = false;
 	}
 
 	private static Collection<Object[]> getTestsToRun() {

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/EqualsJoinTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/EqualsJoinTest.java
@@ -15,6 +15,8 @@ import org.eclipse.rdf4j.sail.shacl.mock.MockInputPlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.EqualsJoin;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Tuple;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -31,8 +33,15 @@ import static junit.framework.TestCase.assertTrue;
  */
 public class EqualsJoinTest {
 
-	{
-		GlobalValidationExecutionLogging.loggingEnabled = true;
+	@BeforeClass
+	public static void beforeClass() {
+		// GlobalValidationExecutionLogging.loggingEnabled = true;
+
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		GlobalValidationExecutionLogging.loggingEnabled = false;
 	}
 
 	@Test

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/InnerJoinTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/InnerJoinTest.java
@@ -16,6 +16,8 @@ import org.eclipse.rdf4j.sail.shacl.planNodes.BufferedPlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.InnerJoin;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Tuple;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -31,8 +33,15 @@ import static junit.framework.TestCase.assertTrue;
  */
 public class InnerJoinTest {
 
-	{
-		GlobalValidationExecutionLogging.loggingEnabled = true;
+	@BeforeClass
+	public static void beforeClass() {
+		// GlobalValidationExecutionLogging.loggingEnabled = true;
+
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		GlobalValidationExecutionLogging.loggingEnabled = false;
 	}
 
 	@Test

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/LeftOuterJoinTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/LeftOuterJoinTest.java
@@ -15,6 +15,8 @@ import org.eclipse.rdf4j.sail.shacl.mock.MockInputPlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.LeftOuterJoin;
 import org.eclipse.rdf4j.sail.shacl.planNodes.PlanNode;
 import org.eclipse.rdf4j.sail.shacl.planNodes.Tuple;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -30,8 +32,15 @@ import static junit.framework.TestCase.assertTrue;
  */
 public class LeftOuterJoinTest {
 
-	{
-		GlobalValidationExecutionLogging.loggingEnabled = true;
+	@BeforeClass
+	public static void beforeClass() {
+		// GlobalValidationExecutionLogging.loggingEnabled = true;
+
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		GlobalValidationExecutionLogging.loggingEnabled = false;
 	}
 
 	@Test

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/MultithreadedTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/MultithreadedTest.java
@@ -22,6 +22,8 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.NotifyingSail;
 import org.eclipse.rdf4j.sail.Sail;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -36,6 +38,11 @@ import java.util.stream.IntStream;
 
 public abstract class MultithreadedTest {
 	SimpleValueFactory vf = SimpleValueFactory.getInstance();
+
+	@AfterClass
+	public static void afterClass() {
+		GlobalValidationExecutionLogging.loggingEnabled = false;
+	}
 
 	@Test
 	public void testDataAndShapes() {

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TempTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TempTest.java
@@ -16,6 +16,8 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -27,8 +29,15 @@ import java.io.StringReader;
  */
 public class TempTest {
 
-	{
-		GlobalValidationExecutionLogging.loggingEnabled = true;
+	@BeforeClass
+	public static void beforeClass() {
+		// GlobalValidationExecutionLogging.loggingEnabled = true;
+
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		GlobalValidationExecutionLogging.loggingEnabled = false;
 	}
 
 	@Test

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TrackAddedStatementsTest.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TrackAddedStatementsTest.java
@@ -19,6 +19,8 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.SailConnection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
@@ -29,10 +31,6 @@ import static junit.framework.TestCase.assertNull;
  * @author Håvard Ottestad
  */
 public class TrackAddedStatementsTest {
-
-	{
-		GlobalValidationExecutionLogging.loggingEnabled = true;
-	}
 
 	@Test
 	public void testCleanup() throws Exception {

--- a/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/BenchmarkJunitTests.java
+++ b/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/benchmark/BenchmarkJunitTests.java
@@ -13,6 +13,7 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
 
 /**
  * @author Håvard Ottestad
@@ -25,11 +26,11 @@ public class BenchmarkJunitTests {
 				.include("")
 				.exclude(ComplexLargeBenchmark.class.getSimpleName())
 				.exclude(NativeStoreBenchmark.class.getSimpleName())
-				.warmupBatchSize(1)
 				.measurementBatchSize(1)
+				.measurementTime(TimeValue.NONE)
 				.measurementIterations(1)
-				.warmupIterations(1)
-				.forks(1)
+				.warmupIterations(0)
+				.forks(0)
 				.build();
 
 		new Runner(opt).run();


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1396 .

Briefly describe the changes proposed in this PR:

* junit testing of benchmark suite now runs faster
* reduced logging
* 
