### PR TITLE
Issues/1504 shacl persitance directory

### DIFF
--- a/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
+++ b/shacl/src/main/java/org/eclipse/rdf4j/sail/shacl/ShaclSail.java
@@ -259,7 +259,7 @@ public class ShaclSail extends NotifyingSailWrapper {
 			if (path.endsWith("/")) {
 				path = path.substring(0, path.length() - 1);
 			}
-			path = path + "-shapes-graph/";
+			path = path + "/shapes-graph/";
 
 			logger.info("Shapes will be persisted in: " + path);
 


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1504 .

Briefly describe the changes proposed in this PR:

* switched from sibling directory to child directory for path where shapes get persisted
* 
* 
