### PR TITLE
Added ES/Solr dependencies to javadoc maven plugin

### DIFF
--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -13,7 +13,7 @@
 
 	<modules>
 		<module>sparql</module>
-        <module>lucene</module>
+		<module>lucene</module>
 		<module>elasticsearch</module>
 		<module>solr</module>
 		<module>store</module>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -15,10 +15,6 @@
 	<name>RDF4J Elastic Search Sail Index</name>
 	<description>StackableSail implementation offering full-text search on literals, based on Elastic Search.</description>
 
-	<properties>
-		<elasticsearch.version>6.5.4</elasticsearch.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -43,4 +39,32 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<additionnalDependencies>
+						<additionnalDependency>
+							<groupId>org.elasticsearch</groupId>
+							<artifactId>elasticsearch</artifactId>
+							<version>${elasticsearch.version}</version>
+						</additionnalDependency>
+						<additionnalDependency>
+							<groupId>org.elasticsearch</groupId>
+							<artifactId>elasticsearch-x-content</artifactId>
+							<version>${elasticsearch.version}</version>
+						</additionnalDependency>
+						<additionnalDependency>
+							<groupId>org.elasticsearch</groupId>
+							<artifactId>elasticsearch</artifactId>
+							<version>${elasticsearch.version}</version>
+						</additionnalDependency>
+					</additionnalDependencies>
+				</configuration>
+			</plugin>
+			</plugins>
+	</build>
 </project>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -39,32 +39,4 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<configuration>
-					<additionnalDependencies>
-						<additionnalDependency>
-							<groupId>org.elasticsearch</groupId>
-							<artifactId>elasticsearch</artifactId>
-							<version>${elasticsearch.version}</version>
-						</additionnalDependency>
-						<additionnalDependency>
-							<groupId>org.elasticsearch</groupId>
-							<artifactId>elasticsearch-x-content</artifactId>
-							<version>${elasticsearch.version}</version>
-						</additionnalDependency>
-						<additionnalDependency>
-							<groupId>org.elasticsearch</groupId>
-							<artifactId>elasticsearch</artifactId>
-							<version>${elasticsearch.version}</version>
-						</additionnalDependency>
-					</additionnalDependencies>
-				</configuration>
-			</plugin>
-			</plugins>
-	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,9 @@
 								</goals>
 							</execution>
 						</executions>
+						<configuration>
+							<source>8</source>
+						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -169,6 +172,9 @@
 								</goals>
 							</execution>
 						</executions>
+						<configuration>
+							<source>8</source>
+						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -216,6 +222,8 @@
 		<jsonldjava.version>0.12.1</jsonldjava.version>
 		<last.japicmp.compare.version>2.0</last.japicmp.compare.version>
 		<jaxb.version>2.3.0</jaxb.version>
+		<solr.version>7.5.0</solr.version>
+		<elasticsearch.version>6.5.4</elasticsearch.version>
 	</properties>
 
 	<dependencyManagement>
@@ -644,7 +652,30 @@
 					<artifactId>maven-javadoc-plugin</artifactId>
 					<version>2.8.1</version>
 					<configuration>
+						<source>8</source>
 						<additionalparam>${javadoc.opts}</additionalparam>
+						<additionnalDependencies>
+							<additionnalDependency>
+								<groupId>org.elasticsearch</groupId>
+								<artifactId>elasticsearch</artifactId>
+								<version>${elasticsearch.version}</version>
+							</additionnalDependency>
+							<additionnalDependency>
+								<groupId>org.elasticsearch</groupId>
+								<artifactId>elasticsearch-x-content</artifactId>
+								<version>${elasticsearch.version}</version>
+							</additionnalDependency>
+							<additionnalDependency>
+								<groupId>org.elasticsearch.client</groupId>
+								<artifactId>transport</artifactId>
+								<version>${elasticsearch.version}</version>
+							</additionnalDependency>
+							<additionnalDependency>
+								<groupId>org.apache.solr</groupId>
+								<artifactId>solr-core</artifactId>
+								<version>${solr.version}</version>
+							</additionnalDependency>
+						</additionnalDependencies>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -13,10 +13,6 @@
 	<name>RDF4J Solr Sail Index</name>
 	<description>StackableSail implementation offering full-text search on literals, based on Solr.</description>
 
-	<properties>
-		<solr.version>7.5.0</solr.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -89,7 +85,6 @@
 			</build>
 		</profile>
 	</profiles>
-	
 	<repositories>
 		<repository>
 			<!-- contains a solr-core transitive dependency -->
@@ -98,5 +93,4 @@
 			<url>https://maven.restlet.com</url>
 		</repository>
 	</repositories>
-	
 </project>

--- a/storage/pom.xml
+++ b/storage/pom.xml
@@ -373,7 +373,7 @@
 					<additionalparam>${javadoc.opts}</additionalparam>
 					<includeDependencySources>true</includeDependencySources>
 					<dependencySourceIncludes>
-						<dependencySourceIncludes>org.eclipse.rdf4j:*</dependencySourceIncludes>
+						<dependencySourceInclude>org.eclipse.rdf4j:*</dependencySourceInclude>
 					</dependencySourceIncludes>
 				</configuration>
 				<executions>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1148 .

Briefly describe the changes proposed in this PR:

* Set source version to 8
* Added ES and Solr dependencies to javadoc maven plugin in parent pom.xml
* Moved ES and Solr versions to parent pom.xml

Even though 'maven clean install -DskipTests' works, running 'maven clean install -DskipTests -Passembly' fails in rdf4j-storage/storage (in attach-javadocs), with 90+ errors about missing packages and symbols.

Actually this is already an issue in JDK8, and can be seen when debugging/logging, but javadoc 8 just continues after the error, so the maven goal succeeds.
But with JDK9 (and 11), it's a fatal error (even with -Xdoclint=none)

Not the prettiest patch, but I couldn't get it to work otherwise (e.g. moving this to solr/pom.xml and elasticsearch/pom.xml didn't seem to work)

Also note that the javadoc maven plugin 2.8.1 uses misspelled "additionnalDependencies" with extra "n", instead of "additionalDependencies" (fixed in newer versions)

CQs:
- [x] CQ 20696 ElasticSearch (server) 6.5.0
- [x] CQ 20697 ElasticSearch X-Content 6.5.0
- [x] CQ 20698  Solr Core 7.5.0